### PR TITLE
Adds more key management. Moves arrow key handler for calibration can…

### DIFF
--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/_lib/transform-settings";
 import { CM, IN } from "@/_lib/unit";
 import useProgArrowKeyHandler from "@/_hooks/useProgArrowKeyHandler";
+import useProgArrowKeyToMatrix from "@/_hooks/useProgArrowKeyToMatrix";
 
 const defaultPoints = [
   // Points that fit on an iPhone SE
@@ -178,9 +179,11 @@ export default function Page() {
     }
   }, []);
 
+  const pdfTranslation = useProgArrowKeyToMatrix(!isCalibrating);
+
   useEffect(() => {
-    setMatrix3d(toMatrix3d(localTransform));
-  }, [localTransform]);
+    setMatrix3d(toMatrix3d(localTransform.mmul(pdfTranslation)));
+  }, [localTransform, pdfTranslation]);
 
   useEffect(() => {
     if (points && points.length === maxPoints) {
@@ -189,9 +192,6 @@ export default function Page() {
       setPerspective(m);
       setLocalTransform(n);
       setCalibrationTransform(n);
-      if (pointToModify === null) {
-        setPointToModify(0);
-      }
     }
 
     function getDstVertices(): Point[] {
@@ -217,30 +217,6 @@ export default function Page() {
     }
     return `invert(1) ${isGreen ? "sepia(100%) saturate(300%) hue-rotate(80deg)" : ""}`;
   }
-
-  function moveWithArrowKey(key: string, px: number) {
-    let offset: Point = { x: 0, y: 0 };
-    switch (key) {
-      case "ArrowUp":
-        offset = applyOffset(offset, { y: -px, x: 0 });
-        break;
-      case "ArrowDown":
-        offset = applyOffset(offset, { y: px, x: 0 });
-        break;
-      case "ArrowLeft":
-        offset = applyOffset(offset, { y: 0, x: -px });
-        break;
-      case "ArrowRight":
-        offset = applyOffset(offset, { y: 0, x: px });
-        break;
-      default:
-        break;
-    }
-    const translation = translate(offset);
-    setLocalTransform(localTransform.mmul(translation));
-  }
-
-  useProgArrowKeyHandler(moveWithArrowKey, !isCalibrating);
 
   return (
     <main

--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -42,7 +42,6 @@ function draw(
   pointToModify: number | null,
   ptDensity: number,
   displayAllCorners?: boolean,
-  rotateTranspose?: number,
 ): void {
   ctx.translate(offset.x, offset.y);
 

--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -2,7 +2,9 @@ import Matrix from "ml-matrix";
 import React, {
   Dispatch,
   SetStateAction,
+  useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -16,6 +18,7 @@ import {
 } from "@/_lib/point";
 import { TransformSettings } from "@/_lib/transform-settings";
 import { CornerColorHex } from "@/_components/theme/colors";
+import useProgArrowKeyPoints from "@/_hooks/useProgArrowKeyPoints";
 
 const maxPoints = 4; // One point per vertex in rectangle
 
@@ -39,6 +42,7 @@ function draw(
   pointToModify: number | null,
   ptDensity: number,
   displayAllCorners?: boolean,
+  rotateTranspose?: number,
 ): void {
   ctx.translate(offset.x, offset.y);
 
@@ -290,33 +294,8 @@ export default function CalibrationCanvas({
     setPanStart(null);
   }
 
-  function modifyPoint(xOffset: number, yOffset: number): void {
-    if (pointToModify !== null) {
-      const newPoints = [...points];
-      newPoints[pointToModify] = {
-        x: newPoints[pointToModify].x + xOffset,
-        y: newPoints[pointToModify].y + yOffset,
-      };
-      setPoints(newPoints);
-    }
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent<HTMLElement>) {
-    if (pointToModify !== null) {
-      switch (e.code) {
-        case "ArrowLeft":
-          modifyPoint(-1, 0);
-          break;
-        case "ArrowUp":
-          modifyPoint(0, -1);
-          break;
-        case "ArrowRight":
-          modifyPoint(1, 0);
-          break;
-        case "ArrowDown":
-          modifyPoint(0, 1);
-          break;
-      }
+  const handleKeyDown = useCallback(
+    function (e: React.KeyboardEvent) {
       if (e.code === "Tab") {
         e.preventDefault();
         if (e.shiftKey) {
@@ -325,18 +304,36 @@ export default function CalibrationCanvas({
             isFourCorners: !transformSettings.isFourCorners,
           });
         } else {
-          const newPointToModify = ((pointToModify || 0) + 1) % points.length;
+          const newPointToModify =
+            (pointToModify === null ? 0 : pointToModify + 1) % points.length;
           setPointToModify(newPointToModify);
         }
+      } else if (e.code === "Escape") {
+        if (pointToModify !== null) {
+          if (e.target instanceof HTMLElement) {
+            e.target.blur();
+          }
+          setPointToModify(null);
+        }
       }
-    }
-  }
+    },
+    [
+      pointToModify,
+      transformSettings,
+      setPointToModify,
+      points.length,
+      setTransformSettings,
+    ],
+  );
+
+  useProgArrowKeyPoints(points, setPoints, pointToModify, isCalibrating);
 
   return (
     <canvas
+      tabIndex={0}
       ref={canvasRef}
       className={className + " outline-none"}
-      onKeyDown={(e) => handleKeyDown(e)}
+      onKeyDown={handleKeyDown}
       onMouseMove={(e: React.MouseEvent) => {
         if ((e.buttons & 1) == 0) {
           handleMouseUp();
@@ -359,7 +356,6 @@ export default function CalibrationCanvas({
             : "grab",
         pointerEvents: isCalibrating ? "auto" : "none",
       }}
-      tabIndex={-1}
     />
   );
 }

--- a/app/_components/theme/colors.ts
+++ b/app/_components/theme/colors.ts
@@ -5,10 +5,10 @@ enum ButtonColor {
 }
 
 enum CornerColorHex {
-  TOPLEFT = "#3b82f6",
-  TOPRIGHT = "#9333ea",
-  BOTTOMRIGHT = "#c2410c",
-  BOTTOMLEFT = "#65a30d",
+  TOPLEFT = "#9333ea",
+  TOPRIGHT = "#3b82f6",
+  BOTTOMRIGHT = "#65a30d",
+  BOTTOMLEFT = "#c2410c",
 }
 
 export { ButtonColor, CornerColorHex };

--- a/app/_hooks/useProgArrowKeyHandler.ts
+++ b/app/_hooks/useProgArrowKeyHandler.ts
@@ -4,29 +4,29 @@ const PIXEL_LIST = [1, 10, 25, 50];
 export default function useProgArrowKeyHandler(
   handler: (key: string, px: number) => void,
   active: boolean,
+  pixelList: number[] = PIXEL_LIST,
 ) {
   const [pixelIdx, setPixelIdx] = useState<number>(0);
   const [timeoutFunc, setTimeoutFunc] = useState<NodeJS.Timeout | null>();
 
   const keydownHandler = useCallback(
     function (e: KeyboardEvent) {
-      e.preventDefault();
-      if (!timeoutFunc && pixelIdx < PIXEL_LIST.length - 1) {
-        console.log("keydown timeout");
-        setTimeoutFunc(
-          setTimeout(() => {
-            setPixelIdx(pixelIdx + 1);
-            setTimeoutFunc(null);
-          }, 600),
-        );
-      }
       if (
         ["ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown"].includes(e.code)
       ) {
-        handler(e.code, PIXEL_LIST[pixelIdx]);
+        e.preventDefault();
+        if (!timeoutFunc && pixelIdx < pixelList.length - 1) {
+          setTimeoutFunc(
+            setTimeout(() => {
+              setPixelIdx(pixelIdx + 1);
+              setTimeoutFunc(null);
+            }, 600),
+          );
+        }
+        handler(e.code, pixelList[pixelIdx]);
       }
     },
-    [timeoutFunc, pixelIdx, handler],
+    [timeoutFunc, pixelIdx, handler, pixelList],
   );
 
   const keyupHandler = useCallback(

--- a/app/_hooks/useProgArrowKeyPoints.ts
+++ b/app/_hooks/useProgArrowKeyPoints.ts
@@ -1,0 +1,45 @@
+import useProgArrowKeyHandler from "@/_hooks/useProgArrowKeyHandler";
+import { applyOffset, Point } from "@/_lib/point";
+import { translate } from "@/_lib/geometry";
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
+import { Matrix } from "ml-matrix";
+
+export default function useProgArrowKeyPoints(
+  points: Point[],
+  setPoints: Dispatch<SetStateAction<Point[]>>,
+  pointToModify: number | null,
+  active: boolean,
+) {
+  function getNewOffset(key: string, px: number) {
+    if (pointToModify !== null) {
+      const newPoints = [...points];
+      let newPoint: Point = points[pointToModify];
+      switch (key) {
+        case "ArrowUp":
+          newPoint = applyOffset(points[pointToModify], { y: -px, x: 0 });
+          break;
+        case "ArrowDown":
+          newPoint = applyOffset(points[pointToModify], { y: px, x: 0 });
+          break;
+        case "ArrowLeft":
+          newPoint = applyOffset(points[pointToModify], { y: 0, x: -px });
+          break;
+        case "ArrowRight":
+          newPoint = applyOffset(points[pointToModify], { y: 0, x: px });
+          break;
+        default:
+          break;
+      }
+      newPoints[pointToModify] = newPoint;
+      setPoints(newPoints);
+    }
+  }
+
+  useProgArrowKeyHandler(
+    getNewOffset,
+    pointToModify !== null && active,
+    [1, 3, 5, 10],
+  );
+
+  return null;
+}

--- a/app/_hooks/useProgArrowKeyToMatrix.ts
+++ b/app/_hooks/useProgArrowKeyToMatrix.ts
@@ -1,0 +1,37 @@
+import useProgArrowKeyHandler from "@/_hooks/useProgArrowKeyHandler";
+import { applyOffset, Point } from "@/_lib/point";
+import { translate } from "@/_lib/geometry";
+import { useEffect, useMemo, useState } from "react";
+import { Matrix } from "ml-matrix";
+
+export default function useProgArrowKeyToMatrix(active: boolean) {
+  const [offset, setOffset] = useState<Point>({ x: 0, y: 0 });
+  const translation: Matrix = useMemo(() => {
+    return translate(offset);
+  }, [offset]);
+
+  function moveWithArrowKey(key: string, px: number) {
+    let newOffset: Point = { x: 0, y: 0 };
+    switch (key) {
+      case "ArrowUp":
+        newOffset = applyOffset(offset, { y: -px, x: 0 });
+        break;
+      case "ArrowDown":
+        newOffset = applyOffset(offset, { y: px, x: 0 });
+        break;
+      case "ArrowLeft":
+        newOffset = applyOffset(offset, { y: 0, x: -px });
+        break;
+      case "ArrowRight":
+        newOffset = applyOffset(offset, { y: 0, x: px });
+        break;
+      default:
+        break;
+    }
+    setOffset(newOffset);
+  }
+
+  useProgArrowKeyHandler(moveWithArrowKey, active);
+
+  return translation;
+}

--- a/app/_lib/transform-settings.ts
+++ b/app/_lib/transform-settings.ts
@@ -1,4 +1,4 @@
-import { Point } from '@/_lib/point';
+import { Point } from "@/_lib/point";
 
 export interface TransformSettings {
   scale: Point;


### PR DESCRIPTION
…vas into react hook that uses progressive movement. Changes the colors of the canvas corners to follow rainbow (a precursor for rotation support). Updates tab handler to use tabIndex, eg. allows all buttons on the page to receive tab focus before tabbing to grid. Once in focus, the tab button will infinitely select corners. Pressing the escape key will defocus the calibration grid and reset tabindex back to the top of the page. Removed default pointToModify corner, as tabIndex should go through all the buttons first before selecting a corner (@courtneypattison do you agree with this approach?)

Also allows for modification of the "sensitivity" of progressive arrow translation. The reason for this is the calibration grid corner translation needs to be less sensitive than PDF translation.

I'd like to get a second pair of eyes on the update to the PDF translation logic. I'm pretty sure "localTransform" does not get saved anywhere, but when I refactored the arrow key handler into a hook, I modified the offset translation to only be present in ```setMatrix3d()```, as opposed to modifying the ```localTransform``` object directly. It does not appear to affect usage on the page, but this works differently than it used to. I just want to be sure this is an acceptable change for the long run.