### PR TITLE
Move calibration grid size description to calibration steps

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -68,6 +68,20 @@ export default function Home() {
             <FullscreenIcon ariaLabel="" />
           </li>
           <li>{t("calibration.drag")}</li>
+          <li>
+            {t.rich("calibration.size", {
+              inchGridLink: (chunks) => (
+                <a href="https://www.mathed.page/puzzles/one-inch-graph-paper.pdf">
+                  {chunks}
+                </a>
+              ),
+              cmGridLink: (chunks) => (
+                <a href="https://mathbits.com/MathBits/StudentResources/GraphPaper/CentimeterFullPage.pdf">
+                  {chunks}
+                </a>
+              ),
+            })}
+          </li>
           <Image src="/demo.gif" width={640} height={260} alt=""></Image>
           <li>{t("calibration.project")}</li>
         </ol>
@@ -134,11 +148,7 @@ export default function Home() {
 
         <h2>{t("faq.title")}</h2>
         <ul>
-          <li>
-            <div>{t("faq.gridSize.question")}</div>
-            {t("faq.gridSize.answer")}
-          </li>
-          <li>
+        <li>
             <div>{t("faq.wrongSizePdf.question")}</div>
             {t.rich("faq.wrongSizePdf.answer", {
               inchGridLink: (chunks) => (

--- a/messages/da.json
+++ b/messages/da.json
@@ -29,6 +29,7 @@
       "input": "Indtast bredde og højde på din skæremåtte.",
       "fullscreen": "Gå til fuld skærm ved at klikke eller tappe ",
       "drag": "Træk i hjørnerne af gitteret, så ternene kommer til at passe med ternene på din skæremåtte. Justér hjørnerne på din tablet eller computer, mens du kigger på skæremåtten. Justér hjørnernes placering indtil gitteret i projektorbilledet passer med skæremåttens gitter. ",
+      "size": "Du behøver ikke at bruge hele din skæremåtte, når du kalibrerer. Brug i stedet så stort et område som muligt, hvor du kan få kalibreringsgitteret til at passe i. Vær sikker på at målene (bredde og højde) på måtten passer med de indtastede mål. ",
       "project": "Når gitteret i projektorbilledet passer med din skæremåtte, klik eller tap"
     },
     "project": {
@@ -64,10 +65,6 @@
     },
     "faq": {
       "title": "FAQ / OSS",
-      "gridSize": {
-        "question": "Spørgsmål: Problemer med at trække gitterets hjørner til kanten af din skæremåtte? ",
-        "answer": "Svar: Du behøver ikke at bruge hele din skæremåtte, når du kalibrerer. Brug i stedet så stort et område som muligt, hvor du kan få kalibreringsgitteret til at passe i. Vær sikker på at målene (bredde og højde) på måtten passer med de indtastede mål. "
-      },
       "wrongSizePdf": {
         "question": "Vises PDF’en for stort eller for småt? ",
         "answer": "Pattern Projector kalibreringsværktæj har ingen zoom, fordi skaleringen bestemmes af størrelsesinfomationen i PDF’en. Vær sikker på, at skaleringen er rigtigt. En god måde at tjekke skaleringen er korrekt eller ej er at vise en tomme eller en centimeter på projektoren og se, om den matcher din skæremåtte. "

--- a/messages/de.json
+++ b/messages/de.json
@@ -29,6 +29,7 @@
       "input": "Füge die Weite und Höhe deiner Schneidematte ein.",
       "fullscreen": "Gehe auf Vollbildmodus, indem du auf das Ikon klickst",
       "drag": "Ziehe die Ecken des Rasters auf die Ecken deiner Schneidematte. Mit Blick auf die Matte, justiere die Ecken am PC oder Tablet. Justiere es solange, bis die Ecken und Linien mit deiner Schneidematte übereinstimmen.",
+      "size": "Es muss nicht die gesamte Matte kalibriert werden, sondern nur der größten Bereich, in den das Kalibrierungsgitter passt. Stelle dabei sicher, dass die Breiten- und Höhenangaben mit denen des Gitters übereinstimmen.",
       "project": "When das projizierte Gitter mit deiner Schneidematte übereinstimmt, klicke auf \"Beamen\"."
     },
     "project": {
@@ -64,10 +65,6 @@
     },
     "faq": {
       "title": "FAQ",
-      "gridSize": {
-        "question": "Hast du Probleme, die Ecken des Gitters an den Rand der Matte zu ziehen?",
-        "answer": "Es muss nicht die gesamte Matte kalibriert werden, sondern nur der größten Bereich, in den das Kalibrierungsgitter passt. Stelle dabei sicher, dass die Breiten- und Höhenangaben mit denen des Gitters übereinstimmen."
-      },
       "wrongSizePdf": {
         "question": "Wird die PDF zu groß oder zu klein projiziert?",
         "answer": "Die Kalibrierung hat keinen Zoom, da der Maßstab der Projektion von den Größenangaben in der PDF-Datei stammt. Stellen Sie sicher, dass das Schnittmuster den richtigen Maßstab hat. Eine gute Möglichkeit um zu überprüfen, ob der Maßstab des Schnittmusters stimmt, ist die Projektion eines <inchGridLink>ein Zoll</inchGridLink> oder <cmGridLink>ein Zentimeter</cmGridLink> Rasters, um zu sehen, ob es mit der Schneidematte übereinstimmt."

--- a/messages/en.json
+++ b/messages/en.json
@@ -29,6 +29,7 @@
       "input": "Input the width and height of your mat.",
       "fullscreen": "Enter full screen mode by clicking (or tapping) ",
       "drag": "Drag the corners of the grid to align with your mat. With your eyes on the mat, adjust the corners on your computer or tablet. Adjust the placement of the corners until the projected grid matches your mat's grid.",
+      "size": "You don't have to calibrate using your entire mat, instead choose the largest area you can fit the calibration grid in and make sure your width and height inputs match the width and height of the grid.",
       "project": "When the projected grid is aligned with your mat, click (or tap) “Project.”"
     },
     "project": {
@@ -64,10 +65,6 @@
     },
     "faq": {
       "title": "FAQ",
-      "gridSize": {
-        "question": "Having trouble dragging the grid corners to the edge of your mat?",
-        "answer": "You don't have to calibrate using your entire mat, instead choose the largest area you can fit the calibration grid in and make sure your width and height inputs match the width and height of the grid."
-      },
       "wrongSizePdf": {
         "question": "Is your PDF projecting too small or large?",
         "answer": "The Pattern Projector calibration tool has no zoom because the scale of the projection comes from the size information in the PDF. Patterns from designers usually have the correct scale, so a change in scale could have been introduced when opening the pattern in Affinity Designer or Inkscape."

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -29,6 +29,7 @@
       "input": "Geef de breedte en hoogte van je snijmat in.",
       "fullscreen": "Ga naar 'Volledig scherm' modus door te klikken (of drukken) op  ",
       "drag": "Sleep de hoeken van het raster tot ze overeenkomen met je snijmat. Stel de hoeken op je computer of tablet bij terwijl je naar de projectie kijkt.",
+      "size": "Je hoeft niet te kalibreren met je hele mat. Kies het grootste gebied op je mat waar het kalibratierooster in past en zorg ervoor dat je breedte- en hoogteinstellingen overeenkomen met het aantal vakjes van je raster.",
       "project": "Als het geprojecteerde grid overeen komt met de snijmat, klik (of druk) dan op 'Projecteer'."
     },
     "project": {
@@ -64,10 +65,6 @@
     },
     "faq": {
       "title": "FAQ",
-      "gridSize": {
-        "question": "Lukt het niet om de hoeken van het raster naar de randen van je snijmat te slepen?",
-        "answer": "Je hoeft niet te kalibreren met je hele mat. Kies het grootste gebied op je mat waar het kalibratierooster in past en zorg ervoor dat je breedte- en hoogteinstellingen overeenkomen met het aantal vakjes van je raster."
-      },
       "wrongSizePdf": {
         "question": "Is je geprojecteerde PDF te klein of te groot?",
         "answer": "Het Pattern Projector kalibratie gereedschap heeft geen 'zoom' functie omdat de schaal van de projectie uit de informatie in de PDF gehaald wordt. Patronen van ontwerpers hebben meestal de juiste schaal. Het zou kunnen dat er een foute schaal ingeslopen is door het patroon te openen in Affinity Designer of Inkscape."


### PR DESCRIPTION
Quick fix #27 I just moved the FAQ about the calibration grid size into the calibration steps to make it more obvious without requiring extra translations. 