### PR TITLE
Menu hide/show

### DIFF
--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -131,13 +131,21 @@ export default function Header({
     }
   }, [isCalibrating, setShowLayerMenu]);
 
+  useEffect(() => {
+    if (fullScreenHandle.active) {
+      setShowNav(false);
+    } else {
+      setShowNav(true);
+    }
+  }, [fullScreenHandle.active]);
+
   return (
     <>
       <header
-        className={`bg-white absolute left-0 w-full z-30 border-b-2 h-20 transition-all duration-700 ${showNav ? "top-0" : "-top-28"}`}
+        className={`bg-white absolute left-0 w-full z-30 border-b-2 transition-all duration-700 h-16 flex items-center ${showNav ? "top-0" : "-top-20"}`}
       >
         <nav
-          className="mx-auto flex max-w-7xl items-center justify-between p-2 lg:px-8"
+          className="mx-auto flex max-w-7xl items-center justify-between p-2 lg:px-8 w-full"
           aria-label="Global"
         >
           <div className="flex items-center gap-2">
@@ -383,22 +391,19 @@ export default function Header({
             </Tooltip>
           </div>
         </nav>
+        {fullScreenHandle.active ? (
+          <IconButton
+            className={`mt-1 px-1 py-0 border-2 border-slate-400 absolute ${showNav ? "top-14" : "top-20"} z-40 left-1/2 transition-all duration-700 focus:ring-0`}
+            onClick={() => setShowNav(!showNav)}
+          >
+            {showNav ? (
+              <ExpandLessIcon ariaLabel={t("menuHide")} />
+            ) : (
+              <ExpandMoreIcon ariaLabel={t("menuShow")} />
+            )}
+          </IconButton>
+        ) : null}
       </header>
-      <Tooltip
-        description={showNav ? t("menuHide") : t("menuShow")}
-        className={`z-40 absolute  transition-all duration-700  left-0 right-0 m-auto ${showNav ? "top-12" : "top-0"}`}
-      >
-        <IconButton
-          className={`mt-1 w-8 px-1 py-0`}
-          onClick={() => setShowNav(!showNav)}
-        >
-          {showNav ? (
-            <ExpandLessIcon ariaLabel={t("menuHide")} />
-          ) : (
-            <ExpandMoreIcon ariaLabel={t("menuShow")} />
-          )}
-        </IconButton>
-      </Tooltip>
     </>
   );
 }

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -393,7 +393,7 @@ export default function Header({
         </nav>
         {fullScreenHandle.active ? (
           <IconButton
-            className={`mt-1 px-1 py-0 border-2 border-slate-400 absolute ${showNav ? "top-14" : "top-20"} z-40 left-1/2 transition-all duration-700 focus:ring-0`}
+            className={`mt-1 px-1 py-1 border-2 border-slate-400 absolute ${showNav ? "top-14" : "top-20"} z-40 left-1/2 transition-all duration-700 focus:ring-0`}
             onClick={() => setShowNav(!showNav)}
           >
             {showNav ? (


### PR DESCRIPTION
I made some changes to the original PR:

1) Default the menu to hidden in full-screen mode (this feels intuitive and I think even expected)
2) Show/hide is only available in full-screen mode
3) Show/hide button now has a border
4) Show/hide button is now in header tag, making the transition more natural
5) Removes containing tooltip, which creates a hidden non-draggable area on the screen

Let me know what you think. Based on the new video in the PFS page, it appears it is expected for the menu to disappear in full-screen mode and to be available again in non full-screen mode. Chrome tells you to hit escape in full-screen mode to get out of it, so I'm hoping most people will understand that that is how full screen works. The button is there in case they do not.