### PR TITLE
Global checkbox for layers menu

### DIFF
--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -21,6 +21,10 @@ import { Layer } from "@/_lib/layer";
 import LayerMenu from "@/_components/layer-menu";
 import useProgArrowKeyToMatrix from "@/_hooks/useProgArrowKeyToMatrix";
 import { visible } from "@/_components/theme/css-functions";
+import { IconButton } from "@/_components/buttons/icon-button";
+import LayersIcon from "@/_icons/layers-icon";
+import Tooltip from "@/_components/tooltip/tooltip";
+import { useTranslations } from "next-intl";
 
 const defaultPoints = [
   // Points that fit on an iPhone SE
@@ -119,6 +123,7 @@ export default function Page() {
   }
 
   // EFFECTS
+  const t = useTranslations("Header");
 
   const requestWakeLock = useCallback(async () => {
     if ("wakeLock" in navigator) {
@@ -288,13 +293,21 @@ export default function Page() {
         />
 
         <LayerMenu
-          className={
-            "absolute transition-all duration-700  " +
-            (showLayerMenu ? "left-0" : "-left-60")
-          }
+          visible={showLayerMenu}
+          setVisible={(visible) => setShowLayerMenu(visible)}
           layers={layers}
           setLayers={setLayers}
         />
+        {layers.size && !showLayerMenu ? (
+          <Tooltip description={showLayerMenu ? t("layersOff") : t("layersOn")}>
+            <IconButton
+              className="absolute left-2 top-20 z-30 px-1.5 py-1.5 border-2 border-slate-400"
+              onClick={() => setShowLayerMenu(true)}
+            >
+              <LayersIcon ariaLabel="layers" />
+            </IconButton>
+          </Tooltip>
+        ) : null}
 
         <CalibrationCanvas
           className={`absolute z-10 ${visible(isCalibrating || gridOn)}`}

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -1,5 +1,4 @@
 import { useTranslations } from "next-intl";
-import Link from "next/link";
 import {
   ChangeEvent,
   Dispatch,
@@ -28,8 +27,6 @@ import PdfIcon from "@/_icons/pdf-icon";
 import Rotate90DegreesCWIcon from "@/_icons/rotate-90-degrees-cw-icon";
 import { TransformSettings } from "@/_lib/transform-settings";
 import { CM, IN } from "@/_lib/unit";
-import LayersIcon from "@/_icons/layers-icon";
-import LayersOffIcon from "@/_icons/layers-off-icon";
 import RecenterIcon from "@/_icons/recenter-icon";
 import Matrix from "ml-matrix";
 import { translate } from "@/_lib/geometry";
@@ -232,20 +229,20 @@ export default function Header({
             </Tooltip>
           </div>
           <div className={`flex items-center gap-2 ${visible(!isCalibrating)}`}>
-            <Tooltip
-              description={showLayerMenu ? t("layersOff") : t("layersOn")}
-            >
-              <IconButton
-                disabled={!layers || layers.size === 0}
-                onClick={() => setShowLayerMenu(!showLayerMenu)}
-              >
-                {showLayerMenu ? (
-                  <LayersIcon ariaLabel={t("layersOn")} />
-                ) : (
-                  <LayersOffIcon ariaLabel={t("layersOff")} />
-                )}
-              </IconButton>
-            </Tooltip>
+            {/*<Tooltip*/}
+            {/*  description={showLayerMenu ? t("layersOff") : t("layersOn")}*/}
+            {/*>*/}
+            {/*  <IconButton*/}
+            {/*    disabled={!layers || layers.size === 0}*/}
+            {/*    onClick={() => setShowLayerMenu(!showLayerMenu)}*/}
+            {/*  >*/}
+            {/*    {showLayerMenu ? (*/}
+            {/*      <LayersIcon ariaLabel={t("layersOn")} />*/}
+            {/*    ) : (*/}
+            {/*      <LayersOffIcon ariaLabel={t("layersOff")} />*/}
+            {/*    )}*/}
+            {/*  </IconButton>*/}
+            {/*</Tooltip>*/}
             <Tooltip description={gridOn ? t("gridOff") : t("gridOn")}>
               <IconButton onClick={() => setGridOn(!gridOn)}>
                 {gridOn ? (

--- a/app/_components/layer-menu.tsx
+++ b/app/_components/layer-menu.tsx
@@ -1,34 +1,69 @@
 import { Layer } from "@/_lib/layer";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useMemo } from "react";
+import { IconButton } from "@/_components/buttons/icon-button";
+import CloseIcon from "@/_icons/close-icon";
 
 export default function LayerMenu({
   className,
   layers,
   setLayers,
+  visible,
+  setVisible,
 }: {
-  className: string | undefined;
+  className?: string | undefined;
   setLayers: Dispatch<SetStateAction<Map<string, Layer>>>;
   layers: Map<string, Layer>;
+  visible: boolean;
+  setVisible: (visible: boolean) => void;
 }) {
   function handleOnChange(key: string, layer: Layer) {
     layer.visible = !layer.visible;
     setLayers(new Map(layers.set(key, layer)));
   }
 
+  const globalCheck = useMemo((): boolean => {
+    const layerArray = [...layers.entries()];
+    return layerArray.filter((e) => e[1].visible).length === layerArray.length;
+  }, [layers]);
+
+  function handleGlobalChange(checked: boolean) {
+    const newMap = new Map();
+    layers.forEach((value, key) => {
+      value.visible = checked;
+      newMap.set(key, value);
+    });
+    setLayers(newMap);
+  }
+
   return (
     <menu
       className={
-        "w-48 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg absolute top-16 z-30 " +
+        "w-48 text-sm font-medium text-gray-900 bg-white border border-gray-200 border-top-0 absolute top-16 z-45 " +
+        `${visible ? "left-0" : "-left-60"} absolute transition-all duration-700` +
         className
       }
     >
+      <li key="global" className="w-full border-b border-gray-200 rounded-t-lg">
+        <div className="flex items-center justify-between ps-3">
+          <input
+            id="global"
+            type="checkbox"
+            className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+            checked={globalCheck}
+            style={{ width: 14 }}
+            onChange={(e) => handleGlobalChange(e.target.checked)}
+          />
+          <IconButton onClick={() => setVisible(false)}>
+            <CloseIcon ariaLabel="close" />
+          </IconButton>
+        </div>
+      </li>
       {[...layers.entries()].map((e) => (
         <li key={e[0]} className="w-full border-b border-gray-200 rounded-t-lg">
           <div className="flex items-center ps-3">
             <input
               id={e[0]}
               type="checkbox"
-              value=""
               className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
               checked={e[1].visible}
               onChange={() => handleOnChange(e[0], e[1])}

--- a/app/_components/layer-menu.tsx
+++ b/app/_components/layer-menu.tsx
@@ -38,7 +38,7 @@ export default function LayerMenu({
   return (
     <menu
       className={
-        "w-48 text-sm font-medium text-gray-900 bg-white border border-gray-200 border-top-0 absolute top-16 z-45 " +
+        "w-48 text-sm font-medium text-gray-900 bg-white border border-gray-200 border-top-0 absolute top-16 z-50 " +
         `${visible ? "left-0" : "-left-60"} absolute transition-all duration-700` +
         className
       }


### PR DESCRIPTION
Also squared off the menu corners (I would like to "attach" this menu to the top menu at some point). Move the show/hide layers button to the left side of the screen instead of the top menu because in full screen mode, it's harder to access layers with the main menu hidden.