### PR TITLE
Added precision mouse/touch movement. 

### DIFF
--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -420,6 +420,8 @@ export default function CalibrationCanvas({
       setPoints(localPoints.map((p) => applyOffset(p, dragOffset)));
       setDragOffset({ x: 0, y: 0 });
       setPanStart(null);
+    } else {
+        setPoints(localPoints);
     }
     setIsPrecisionMovement(false);
     setDragStartTime(null);
@@ -436,6 +438,7 @@ export default function CalibrationCanvas({
 
   function handleTouchUp() {
     localStorage.setItem("points", JSON.stringify(localPoints));
+    setPoints(localPoints);
     setPointToModify(null);
     setPanStart(null);
     setIsPrecisionMovement(false);

--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -43,8 +43,8 @@ function draw(
   isCalibrating: boolean,
   pointToModify: number | null,
   ptDensity: number,
+  isPrecisionMovement: boolean,
   displayAllCorners?: boolean,
-  isPrecisionMovement: boolean
 ): void {
   ctx.translate(offset.x, offset.y);
 
@@ -229,8 +229,6 @@ export default function CalibrationCanvas({
   const [dragStartPoint, setDragStartPoint] = useState<Point | null>(null);
   const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | null>(null);
 
-
-
   useEffect(() => {
     if (canvasRef !== null && canvasRef.current !== null) {
       const canvas = canvasRef.current;
@@ -248,8 +246,8 @@ export default function CalibrationCanvas({
           isCalibrating,
           pointToModify,
           ptDensity,
-          transformSettings.isFourCorners,
           isPrecisionMovement,
+          transformSettings.isFourCorners,
         );
       }
     }
@@ -297,7 +295,7 @@ export default function CalibrationCanvas({
     }
   }
 
-function handleMove(p: Point, filter: number) {
+  function handleMove(p: Point, filter: number) {
     if (pointToModify !== null) {
       //Check if we should active precision movement
       if (
@@ -327,10 +325,17 @@ function handleMove(p: Point, filter: number) {
 
 
       const newPoints = [...points];
-      const destination = {
-        x: dragStartPoint.x + ((p.x - dragStartPoint.x) / (isPrecisionMovement ? PRECISION_MOVEMENT_RATIO : 1)),
-        y: dragStartPoint.y + ((p.y - dragStartPoint.y) / (isPrecisionMovement ? PRECISION_MOVEMENT_RATIO : 1)),
-      }	
+      let destination = {
+        x: p.x,
+        y: p.y
+      }
+      if (dragStartPoint !== null)
+      {
+        destination = {
+          x: dragStartPoint.x + ((p.x - dragStartPoint.x) / (isPrecisionMovement ? PRECISION_MOVEMENT_RATIO : 1)),
+          y: dragStartPoint.y + ((p.y - dragStartPoint.y) / (isPrecisionMovement ? PRECISION_MOVEMENT_RATIO : 1))
+        }
+      }
       const offset = {
         x: (destination.x - newPoints[pointToModify].x),
         y: (destination.y - newPoints[pointToModify].y),
@@ -371,8 +376,6 @@ function handleMove(p: Point, filter: number) {
       setTimeoutId(null);
     }
   }
-
-
 
   function handleTouchUp() {
     localStorage.setItem("points", JSON.stringify(points));


### PR DESCRIPTION
If the user presses down on a calibration point and doesn't move more than 4 canvas units in 500ms, precision movement mode is activated. The calibration point will appear as a crosshair instead of circle, and the movement of the point will be at a 5:1 ratio to the mouse movements.

Values for delay, movement threshold, and movement ratio are adjustable. The values I picked seem right to me, but you can play around with them before merging if you'd like. Cheers.