### PR TITLE
Axis-locked Constrained drag + mouse out during drag bug fix

### DIFF
--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -362,7 +362,8 @@ export default function Page() {
           setTransformSettings={setTransformSettings}
         />
         <Draggable
-          className={`cursor-grabbing select-none ${visible(!isCalibrating)}`}
+          viewportClassName={`select-none ${visible(!isCalibrating)}`}
+          className={`select-none ${visible(!isCalibrating)}`}
           localTransform={localTransform}
           setLocalTransform={setLocalTransform}
           perspective={perspective}

--- a/app/_components/draggable.tsx
+++ b/app/_components/draggable.tsx
@@ -91,11 +91,11 @@ export default function Draggable({
       const dest = transformPoint(p, perspective);
       const tx = dest.x - dragStart.x;
       const ty = dest.y - dragStart.y;
-      var vec = {x: tx, y:ty};
+      let vec = {x: tx, y:ty};
       if (isAxisLocked){
         vec = toSingleAxisVector(vec);
       }
-      let m = translate(vec);
+      const m = translate(vec);
       setLocalTransform(transformStart.mmul(m));
     }
   }

--- a/app/_components/draggable.tsx
+++ b/app/_components/draggable.tsx
@@ -2,7 +2,7 @@ import { Matrix } from "ml-matrix";
 import {
   Dispatch,
   LegacyRef,
-  MouseEvent,
+  MouseEvent as ReactMouseEvent,
   ReactNode,
   SetStateAction,
   useState,
@@ -10,7 +10,7 @@ import {
 } from "react";
 
 import { transformPoint, translate } from "@/_lib/geometry";
-import { mouseToCanvasPoint, Point, touchToCanvasPoint } from "@/_lib/point";
+import { mouseToCanvasPoint, Point, touchToCanvasPoint, nativeMouseToCanvasPoint} from "@/_lib/point";
 
 export default function Draggable({
   children,
@@ -64,15 +64,18 @@ export default function Draggable({
   /* This effect allows for the mouse to move the element
      even if it is no longer hovering on it */
   useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      handleMove(nativeMouseToCanvasPoint(e));
+    };
     if (dragStart !== null ) {
       // Attach global event listeners when dragging starts
-      window.addEventListener('mousemove', handleOnMouseMove);
+      window.addEventListener('mousemove', handleMouseMove);
       window.addEventListener('mouseup', handleOnEnd);
     }
 
     // Cleanup global event listeners on component unmount
     return () => {
-      window.removeEventListener('mousemove', handleOnMouseMove);
+      window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleOnEnd);
     };
   }, [dragStart, isAxisLocked]); // Re-run effect if isDragging changes or isAxisLocked changes
@@ -80,7 +83,7 @@ export default function Draggable({
   /* Update the currentMousePos every time the mouse moves */
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
-      const newMousePos = mouseToCanvasPoint(e);
+      const newMousePos = nativeMouseToCanvasPoint(e);
       setCurrentMousePos(newMousePos);
     };
 
@@ -101,19 +104,6 @@ export default function Draggable({
   function handleOnEnd(): void {
     setDragStart(null);
     setTransformStart(null);
-  }
-
-  function handleOnMouseMove(e: MouseEvent<HTMLDivElement>): void {
-    if (e.buttons & 1 && dragStart === null) {
-      handleOnStart(mouseToCanvasPoint(e));
-      return;
-    }
-
-    if ((e.buttons & 1) === 0 && dragStart !== null) {
-      handleOnEnd();
-      return;
-    }
-    handleMove(mouseToCanvasPoint(e));
   }
 
   function toSingleAxisVector(vec: Point): Point{

--- a/app/_lib/point.ts
+++ b/app/_lib/point.ts
@@ -17,6 +17,10 @@ export function mouseToCanvasPoint(e: React.MouseEvent<Element>): Point {
   return { x: e.clientX, y: e.clientY };
 }
 
+export function nativeMouseToCanvasPoint(e: MouseEvent): Point {
+  return { x: e.pageX, y: e.pageY };
+}
+
 export function touchToCanvasPoint(e: React.TouchEvent<Element>): Point {
   return { x: e.touches[0].clientX, y: e.touches[0].clientY };
 }

--- a/patches/react-pdf+7.7.0.patch
+++ b/patches/react-pdf+7.7.0.patch
@@ -18,6 +18,18 @@ index b5e8e11..5fb6371 100644
          canvas.style.visibility = 'hidden';
          const renderContext = {
              annotationMode: renderForms ? ANNOTATION_MODE.ENABLE_FORMS : ANNOTATION_MODE.ENABLE,
+diff --git a/node_modules/react-pdf/dist/cjs/Page/TextLayer.css b/node_modules/react-pdf/dist/cjs/Page/TextLayer.css
+index 592ec1c..fc3b617 100644
+--- a/node_modules/react-pdf/dist/cjs/Page/TextLayer.css
++++ b/node_modules/react-pdf/dist/cjs/Page/TextLayer.css
+@@ -101,7 +101,6 @@
+   position: absolute;
+   inset: 100% 0 0;
+   z-index: -1;
+-  cursor: default;
+   user-select: none;
+ }
+ 
 diff --git a/node_modules/react-pdf/dist/esm/Page/PageCanvas.js b/node_modules/react-pdf/dist/esm/Page/PageCanvas.js
 index 1b72392..0df7d1a 100644
 --- a/node_modules/react-pdf/dist/esm/Page/PageCanvas.js
@@ -38,3 +50,27 @@ index 1b72392..0df7d1a 100644
          canvas.style.visibility = 'hidden';
          const renderContext = {
              annotationMode: renderForms ? ANNOTATION_MODE.ENABLE_FORMS : ANNOTATION_MODE.ENABLE,
+diff --git a/node_modules/react-pdf/dist/esm/Page/TextLayer.css b/node_modules/react-pdf/dist/esm/Page/TextLayer.css
+index 592ec1c..fc3b617 100644
+--- a/node_modules/react-pdf/dist/esm/Page/TextLayer.css
++++ b/node_modules/react-pdf/dist/esm/Page/TextLayer.css
+@@ -101,7 +101,6 @@
+   position: absolute;
+   inset: 100% 0 0;
+   z-index: -1;
+-  cursor: default;
+   user-select: none;
+ }
+ 
+diff --git a/node_modules/react-pdf/src/Page/TextLayer.css b/node_modules/react-pdf/src/Page/TextLayer.css
+index 592ec1c..fc3b617 100644
+--- a/node_modules/react-pdf/src/Page/TextLayer.css
++++ b/node_modules/react-pdf/src/Page/TextLayer.css
+@@ -101,7 +101,6 @@
+   position: absolute;
+   inset: 100% 0 0;
+   z-index: -1;
+-  cursor: default;
+   user-select: none;
+ }
+ 


### PR DESCRIPTION
When holding the control key, the PDF pattern will only be moved exactly along the X or Y axis (whichever part of the vector is bigger). The key can be pressed before or after the drag has begun.

Also added a fix for when the mouse moves off the element when dragging. Before, the movement would stop being updated because it was attached to the onMouseMove event of the element rather than the window. The onMouseMove event of the window gets used now instead which fixes this issue. There may be a way to achieve a similar react while still using React.MouseEvent, but this was the simplest solution IMO.