### PR TITLE
Resolves #104. Squishes layers into a Map keyed by name instead of id

### DIFF
--- a/app/_components/pdf-custom-renderer.tsx
+++ b/app/_components/pdf-custom-renderer.tsx
@@ -14,6 +14,7 @@ import type {
   PDFDocumentProxy,
 } from "pdfjs-dist/types/src/display/api.js";
 import { Layer } from "@/_lib/layer";
+import { PDFPageProxy } from "pdfjs-dist";
 
 function erodeImageData(imageData: ImageData, output: ImageData) {
   const { width, height, data } = imageData;
@@ -93,6 +94,8 @@ export default function CustomRenderer(
   const page = pageContext.page;
   const pdf = docContext.pdf;
   const canvasElement = useRef<HTMLCanvasElement>(null);
+  const userUnit = (page as PDFPageProxy).userUnit || 1;
+
   const CSS = 96.0;
   const PDF = 72.0;
   const PDF_TO_CSS_UNITS = CSS / PDF;
@@ -191,7 +194,6 @@ export default function CustomRenderer(
   useEffect(drawPageOnCanvas, [
     canvasElement,
     page,
-    viewport,
     renderViewport,
     layers,
     pdf,
@@ -206,8 +208,9 @@ export default function CustomRenderer(
       width={Math.floor(renderViewport.width)}
       height={Math.floor(renderViewport.height)}
       style={{
-        width: Math.floor(viewport.width * PDF_TO_CSS_UNITS) + "px",
-        height: Math.floor(viewport.height * PDF_TO_CSS_UNITS) + "px",
+        width: Math.floor(viewport.width * PDF_TO_CSS_UNITS * userUnit) + "px",
+        height:
+          Math.floor(viewport.height * PDF_TO_CSS_UNITS * userUnit) + "px",
       }}
     />
   );

--- a/app/_components/pdf-viewer.tsx
+++ b/app/_components/pdf-viewer.tsx
@@ -68,8 +68,8 @@ export default function PdfViewer({
   }
 
   function onPageLoadSuccess(pdfProxy: PDFPageProxy) {
-    setPageWidth(pdfProxy.view[2]);
-    setPageHeight(pdfProxy.view[3]);
+    setPageWidth(pdfProxy.view[2] * (pdfProxy.userUnit || 1));
+    setPageHeight(pdfProxy.view[3] * (pdfProxy.userUnit || 1));
   }
 
   const customRenderer = useCallback(


### PR DESCRIPTION
This does not remove layers that do not have content, but it removes duplicate layers by condensing files with multiples of the same layer names to a single named layer with multiple ids.