### PR TITLE
Visual bug fix for when units are changed.

### DIFF
--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -352,7 +352,6 @@ export default function Page() {
           setPoints={setPoints}
           pointToModify={pointToModify}
           setPointToModify={setPointToModify}
-          perspective={calibrationTransform}
           width={+width}
           height={+height}
           isCalibrating={isCalibrating}


### PR DESCRIPTION
Fix for issue #110 

Perspective matrix is now calculated in the same useEffect as the when the draw function is called. Removed localPerspective state as it is unnecessary. This should also improve performance during drag, as each time a point was moved, the canvas was being drawn multiple times: once for when localPoints changed, and again when that tickled down to localPerspective updating. This fix makes sure the canvas is only redrawn when necessary.

Simply updating the dependency list for the draw useEffect wasn't adequate and introduced other visual bugs.