### PR TITLE
Concave polygon visual bug fix + other visual bug fixes

### DIFF
--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -29,14 +29,6 @@ import { EdgeInsets } from "@/_lib/edge-insets";
 import StitchMenu from "@/_components/stitch-menu";
 import FlexWrapIcon from "@/_icons/flex-wrap-icon";
 
-const defaultPoints = [
-  // Points that fit on an iPhone SE
-  { x: 100, y: 300 },
-  { x: 300, y: 300 },
-  { x: 300, y: 600 },
-  { x: 100, y: 600 },
-];
-
 export default function Page() {
   // Default dimensions should be available on most cutting mats and large enough to get an accurate calibration
   const defaultWidthDimensionValue = "24";
@@ -45,7 +37,7 @@ export default function Page() {
 
   const handle = useFullScreenHandle();
 
-  const [points, setPoints] = useState<Point[]>(defaultPoints);
+  const [points, setPoints] = useState<Point[]>([]);
   const [transformSettings, setTransformSettings] = useState<TransformSettings>(
     getDefaultTransforms(),
   );

--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -296,14 +296,14 @@ export default function CalibrationCanvas({
 	  setPrecisionActivationPoint(prevPoint => localPoints[pointToModify]);
   }, [isPrecisionMovement, pointToModify]);
 
-  /* Used to create the fill pattern */
+  /* Used to create the error fill pattern */
   useEffect(() => {
     if (!canvasRef === null || canvasRef.current === null)
       return;
     const canvas = canvasRef.current;
       const ctx = canvas.getContext('2d');
       if (ctx) {
-        patternRef.current = createCheckerboardPattern(ctx);
+        patternRef.current = createCheckerboardPattern(ctx, 3, "#555", "#CCC");
       }
   }, []);
 

--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -546,6 +546,11 @@ export default function CalibrationCanvas({
   }
 
   function handleMouseUp() {
+    /* Nothing to do. This short circuit is required to prevent setting
+     * the localStorage of the points to invalid values */
+    if (panStart === null && dragStartPoint === null)
+      return;
+
     localStorage.setItem("points", JSON.stringify(localPoints));
     if (panStart) {
       setPoints(localPoints.map((p) => applyOffset(p, dragOffset)));

--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -27,39 +27,45 @@ const PRECISION_MOVEMENT_DELAY = 500;
 
 function createCheckerboardPattern(
   ctx: CanvasRenderingContext2D,
-  size: int = 3,
+  size: number = 3,
   color1: string = "black",
   color2: string = "#CCC"
   ): CanvasPattern {
   /* We first create a new canvas on which to draw the pattern */
   const patternCanvas = document.createElement('canvas');
-  const patternCtx = patternCanvas.getContext('2d');
+  try {
+    const patternCtx = patternCanvas.getContext('2d');
 
-  if (!patternCtx) {
-    throw new Error('Failed to get 2D context from pattern canvas');
+    if (!patternCtx) {
+      throw new Error('Failed to get 2D context from pattern canvas');
+    }
+  
+    /* Integer which defines the size of a checkboard square (in pixels) */
+    size = Math.round(size)
+
+    patternCanvas.width = size*2;
+    patternCanvas.height = size*2;
+
+    /* Draw the checkerboard pattern */
+    patternCtx.fillStyle = color1;
+    patternCtx.fillRect(0, 0, size, size);
+    patternCtx.fillRect(size, size, size, size);
+    patternCtx.fillStyle = color2;
+    patternCtx.fillRect(size, 0, size, size);
+    patternCtx.fillRect(0, size, size, size);
+
+    /* Create the pattern from the canvas */
+    const pattern = ctx.createPattern(patternCanvas, 'repeat');
+
+    if (!pattern) {
+      throw new Error('Failed to create pattern from canvas');
+    }
+
+    return pattern;
+  } finally {
+    /* Clean up the dynamically created canvas element */
+    patternCanvas.remove();
   }
-
-  /* Integer which defines the size of the checkboard 'pixel' */
-
-  patternCanvas.width = size*2;
-  patternCanvas.height = size*2;
-
-  /* Draw the checkerboard pattern */
-  patternCtx.fillStyle = color1;
-  patternCtx.fillRect(0, 0, size, size);
-  patternCtx.fillRect(size, size, size, size);
-  patternCtx.fillStyle = color2;
-  patternCtx.fillRect(size, 0, size, size);
-  patternCtx.fillRect(0, size, size, size);
-
-  /* Create the pattern from the canvas */
-  const pattern = ctx.createPattern(patternCanvas, 'repeat');
-
-  if (!pattern) {
-    throw new Error('Failed to create pattern from canvas');
-  }
-
-  return pattern;
 }
 
 function getStrokeStyle(pointToModify: number) {

--- a/app/_lib/drawing.ts
+++ b/app/_lib/drawing.ts
@@ -1,0 +1,44 @@
+
+/* Creates a checkerboard pattern for the canvas context */
+export function createCheckerboardPattern(
+  ctx: CanvasRenderingContext2D,
+  size: number = 3,
+  color1: string = "black",
+  color2: string = "#CCC"
+  ): CanvasPattern {
+  /* We first create a new canvas on which to draw the pattern */
+  const patternCanvas = document.createElement('canvas');
+  try {
+    const patternCtx = patternCanvas.getContext('2d');
+
+    if (!patternCtx) {
+      throw new Error('Failed to get 2D context from pattern canvas');
+    }
+  
+    /* Integer which defines the size of a checkboard square (in pixels) */
+    size = Math.round(size)
+
+    patternCanvas.width = size*2;
+    patternCanvas.height = size*2;
+
+    /* Draw the checkerboard pattern */
+    patternCtx.fillStyle = color1;
+    patternCtx.fillRect(0, 0, size, size);
+    patternCtx.fillRect(size, size, size, size);
+    patternCtx.fillStyle = color2;
+    patternCtx.fillRect(size, 0, size, size);
+    patternCtx.fillRect(0, size, size, size);
+
+    /* Create the pattern from the canvas */
+    const pattern = ctx.createPattern(patternCanvas, 'repeat');
+
+    if (!pattern) {
+      throw new Error('Failed to create pattern from canvas');
+    }
+
+    return pattern;
+  } finally {
+    /* Clean up the dynamically created canvas element */
+    patternCanvas.remove();
+  }
+}

--- a/app/_lib/geometry.ts
+++ b/app/_lib/geometry.ts
@@ -184,3 +184,40 @@ export function interp(from: Point, to: Point, portion: number): Point {
   const rest = 1.0 - portion;
   return { x: to.x * portion + from.x * rest, y: to.y * portion + from.y * rest };
 }
+
+/* Returns true if the list of points define a concave polygon, false otherwise */
+export function checkIsConcave(points: Point[]): boolean {
+  const n = points.length;
+  if (n < 4) {
+    return false; // A polygon with less than 4 points is always convex
+  }
+
+  let prevOrientation = 0;
+  for (let i = 0; i < n; i++) {
+    const p1 = points[i];
+    const p2 = points[(i + 1) % n];
+    const p3 = points[(i + 2) % n];
+
+    const orientation = getOrientation(p1, p2, p3);
+    if (orientation !== 0) {
+      if (prevOrientation === 0) {
+        prevOrientation = orientation;
+      } else if (orientation !== prevOrientation) {
+        return true; // The polygon is concave
+      }
+    }
+  }
+
+  return false; // The polygon is convex
+}
+
+function getOrientation(p1: Point, p2: Point, p3: Point): number {
+  const crossProduct = (p2.x - p1.x) * (p3.y - p1.y) - (p2.y - p1.y) * (p3.x - p1.x);
+  if (crossProduct < 0) {
+    return -1; // Clockwise orientation
+  } else if (crossProduct > 0) {
+    return 1; // Counterclockwise orientation
+  } else {
+    return 0; // Collinear points
+  }
+}


### PR DESCRIPTION
Changes:

- When the calibration points create a convex polygon, the grid and text are no longer rendered. Instead, a checkboard fill pattern is rendered to indicate that the points are invalid. This prevents some of the visual wonkiness when the perspective transform is invalid.
- Created app/_lib/drawing.ts to hold canvas drawing functions to keep calibration-canvas.tsx from becoming excessively long.
- Bug fix for issue #114 : handleMouseUp short circuits if there's no drag to finish.
- Bug fix for single frame page load visual bug: remove default points (replacing with an empty array). This ensures the calibration page is not rendered until it gets "proper" points. Everything seems already set up to allow this change.