### PR TITLE
Hide cursor timer + grid line color fix

### DIFF
--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -71,6 +71,10 @@ function draw(
   const color_c = interpolateColorRing(
     [lightColor, greenColor, lightColor],
     transitionProgress);
+  /* Grid line color for projection mode */
+  const color_d = interpolateColorRing(
+    [darkColor, greenColor, lightColor],
+    transitionProgress);
 
   if (isCalibrating) {
     ctx.fillStyle = color_a;
@@ -136,7 +140,7 @@ function draw(
     }
   } else if (!isConcave) {
     /* Only draw the grid if the polygon is convex */
-    ctx.strokeStyle = color_c
+    ctx.strokeStyle = color_d
     ctx.setLineDash([1]);
     drawGrid(ctx, width, height, perspective, 8, ptDensity, isCalibrating);
   }


### PR DESCRIPTION

Solution for issue #78 . Cursor gets hidden after 1.5 seconds idle on the projection page.

Also fixed a small bug with the color of the grid lines in calibration-canvas when in project light mode.