### PR TITLE
vcenter the height of the text on the canvas

### DIFF
--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -214,6 +214,12 @@ function drawDimensionLabels(
   ctx.fillStyle = "white";
   const widthText = `${width}`;
   const heightText = `${height}`;
+
+  // Get the actual font height, numbers are all above the baseline on the font used; would need adjustment to work with
+  // fancier fonts where e.g. the 9 descends.
+  const metrics = ctx.measureText(heightText);
+  const height_offset = (metrics.actualBoundingBoxAscent / 2);
+
   const line = transformPoints(
     [
       {
@@ -222,7 +228,7 @@ function drawDimensionLabels(
       },
       {
         x: 0,
-        y: height * 0.5 * ptDensity,
+        y: (height * 0.5 * ptDensity) - height_offset,
       },
     ],
     perspective,


### PR DESCRIPTION
This one irrationally bugged me - the height of the canvas was drawn at the middle of the left edge, without taking the actual text height into account, so the bottom of the text was at the middle, not the middle. I've tested this on current Firefox and Chrome on Windows, I don't know about support on older devices for measureText and actualBoundingBoxAscent. Is there anyone with such a device who can test?