### PR TITLE
Matrix based transforms

### DIFF
--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -200,10 +200,10 @@ export default function Page() {
 
   useEffect(() => {
     /* Combine the translation portion of tranformSettings
-     * with the localTransformMatrix */
+     * with the localTransformMatrix. Note that the transformSettings
+     * matrix must be scaled by ptDensity first */
     const ptDensity = getPtDensity(unitOfMeasure);
     const translationMatrix = extractTranslationMatrix(Matrix.mul(transformSettings.matrix, ptDensity));
-    console.log(JSON.stringify(translationMatrix))
     const m = localTransform.mmul(translationMatrix);
     setMatrix3d(toMatrix3d(m.mmul(pdfTranslation)));
 

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -269,7 +269,13 @@ export default function Page() {
     const observer = new ResizeObserver((entries) => {
       for (let entry of entries) {
         const { width, height } = entry.contentRect;
-        setPdfDimensions({ width, height });
+        /* Only trigger if the dimension is non-zero
+         * and different that the current dimension */
+        if (width !== 0 && height !== 0 &&
+          (width != pdfDimensions.width 
+          || height != pdfDimensions.height)
+        )
+          setPdfDimensions({ width, height });
       }
     });
 
@@ -282,7 +288,7 @@ export default function Page() {
         observer.unobserve(pdfRef.current);
       }
     };
-  }, []);
+  }, [pdfDimensions]);
 
   useEffect(() => {
     const ptDensity = getPtDensity(unitOfMeasure);

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -420,9 +420,6 @@ export default function Page() {
             >
               <div
                 className={"border-8 border-purple-700"}
-                style={{
-                  transformOrigin: "center",
-                }}
               >
                 <PDFViewer
                   file={file}

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -188,16 +188,24 @@ export default function Page() {
       if (localSettings.unitOfMeasure) {
         setUnitOfMeasure(localSettings.unitOfMeasure);
       }
+
       const newDisplaySettings: {
+        overlayMode?: OverlayMode;
         inverted?: boolean;
         isInvertedGreen?: boolean;
         isFourCorners?: boolean;
       } = {};
+      
+      const defaultDS = getDefaultDisplaySettings();
 
-      newDisplaySettings.inverted = localSettings.inverted || false;
-      newDisplaySettings.isInvertedGreen =
-        localSettings.isInvertedGreen || false;
-      newDisplaySettings.isFourCorners = localSettings.isFourCorners || false;
+      newDisplaySettings.overlayMode = localSettings.overlayMode !== undefined 
+        ? localSettings.overlayMode : defaultDS.overlayMode;
+      newDisplaySettings.inverted = localSettings.inverted !== undefined
+        ? localSettings.inverted : defaultDS.inverted;
+      newDisplaySettings.isInvertedGreen = localSettings.isInvertedGreen !== undefined
+        ? localSettings.isInvertedGreen : defaultDS.isInvertedGreen;
+      newDisplaySettings.isFourCorners = localSettings.isFourCorners !== undefined
+        ? localSettings.isFourCorners : defaultDS.isFourCorners;
       setDisplaySettings({ ...displaySettings, ...newDisplaySettings });
     }
   }, []);
@@ -289,6 +297,7 @@ export default function Page() {
               setDisplaySettings(newSettings);
               if (newSettings) {
                 updateLocalSettings({
+                  overlayMode: newSettings.overlayMode,
                   inverted: newSettings.inverted,
                   isInvertedGreen: newSettings.isInvertedGreen,
                   isFourCorners: newSettings.isFourCorners,

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -22,6 +22,10 @@ import {
   getDefaultTransforms,
   TransformSettings,
 } from "@/_lib/transform-settings";
+import {
+  getDefaultDisplaySettings,
+  DisplaySettings,
+} from "@/_lib/display-settings";
 import { CM, IN, getPtDensity } from "@/_lib/unit";
 import { Layer } from "@/_lib/layer";
 import LayerMenu from "@/_components/layer-menu";
@@ -46,7 +50,9 @@ export default function Page() {
   const [transformSettings, setTransformSettings] = useState<TransformSettings>(
     getDefaultTransforms(),
   );
-  const [overlayMode, setOverlayMode] = useState<OverlayMode>(OverlayMode.GRID);
+  const [displaySettings, setDisplaySettings] = useState<DisplaySettings>(
+    getDefaultDisplaySettings(),
+  );
   const [pointToModify, setPointToModify] = useState<number | null>(null);
   const [width, setWidth] = useState(defaultWidthDimensionValue);
   const [height, setHeight] = useState(defaultHeightDimensionValue);
@@ -182,17 +188,17 @@ export default function Page() {
       if (localSettings.unitOfMeasure) {
         setUnitOfMeasure(localSettings.unitOfMeasure);
       }
-      const newTransformSettings: {
+      const newDisplaySettings: {
         inverted?: boolean;
         isInvertedGreen?: boolean;
         isFourCorners?: boolean;
       } = {};
 
-      newTransformSettings.inverted = localSettings.inverted || false;
-      newTransformSettings.isInvertedGreen =
+      newDisplaySettings.inverted = localSettings.inverted || false;
+      newDisplaySettings.isInvertedGreen =
         localSettings.isInvertedGreen || false;
-      newTransformSettings.isFourCorners = localSettings.isFourCorners || false;
-      setTransformSettings({ ...transformSettings, ...newTransformSettings });
+      newDisplaySettings.isFourCorners = localSettings.isFourCorners || false;
+      setDisplaySettings({ ...displaySettings, ...newDisplaySettings });
     }
   }, []);
 
@@ -254,7 +260,7 @@ export default function Page() {
   return (
     <main
       ref={noZoomRefCallback}
-      className={`${(transformSettings.inverted || transformSettings.isInvertedGreen) && "dark"} w-full h-full absolute overflow-hidden touch-none`}
+      className={`${(displaySettings.inverted || displaySettings.isInvertedGreen) && "dark"} w-full h-full absolute overflow-hidden touch-none`}
     >
       <div className="bg-white dark:bg-black dark:text-white">
         <FullScreen handle={handle}>
@@ -277,8 +283,10 @@ export default function Page() {
               updateLocalSettings({ unitOfMeasure: newUnit });
             }}
             transformSettings={transformSettings}
-            setTransformSettings={(newSettings) => {
-              setTransformSettings(newSettings);
+            setTransformSettings={setTransformSettings}
+            displaySettings={displaySettings}
+            setDisplaySettings={(newSettings) => {
+              setDisplaySettings(newSettings);
               if (newSettings) {
                 updateLocalSettings({
                   inverted: newSettings.inverted,
@@ -288,8 +296,6 @@ export default function Page() {
               }
             }}
             pageCount={pageCount}
-            overlayMode={overlayMode}
-            setOverlayMode={setOverlayMode}
             layers={layers}
             showLayerMenu={showLayerMenu}
             setShowLayerMenu={setShowLayerMenu}
@@ -344,9 +350,8 @@ export default function Page() {
             height={+height}
             isCalibrating={isCalibrating}
             unitOfMeasure={unitOfMeasure}
-            transformSettings={transformSettings}
-            setTransformSettings={setTransformSettings}
-            overlayMode={overlayMode}
+            displaySettings={displaySettings}
+            setDisplaySettings={setDisplaySettings}
           />
           <Draggable
             viewportClassName={`select-none ${visible(!isCalibrating)} bg-white dark:bg-black transition-all duration-700 `}
@@ -362,8 +367,8 @@ export default function Page() {
                 transform: `${matrix3d}`,
                 transformOrigin: "0 0",
                 filter: getInversionFilters(
-                  transformSettings.inverted,
-                  transformSettings.isInvertedGreen,
+                  displaySettings.inverted,
+                  displaySettings.isInvertedGreen,
                 ),
               }}
             >

--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -23,7 +23,7 @@ import {
   transformPoint,
 } from "@/_lib/geometry";
 import { mouseToCanvasPoint, Point, touchToCanvasPoint } from "@/_lib/point";
-import { TransformSettings } from "@/_lib/transform-settings";
+import { DisplaySettings } from "@/_lib/display-settings";
 import { CornerColorHex } from "@/_components/theme/colors";
 import useProgArrowKeyPoints from "@/_hooks/useProgArrowKeyPoints";
 
@@ -59,7 +59,7 @@ function drawCalibration(cs: CanvasState): void {
   }
 
   ctx.globalCompositeOperation = "difference";
-  if (cs.transformSettings.isFourCorners) {
+  if (cs.displaySettings.isFourCorners) {
     cs.points.forEach((point, index) => {
       ctx.beginPath();
       ctx.strokeStyle = getStrokeStyle(index);
@@ -131,7 +131,7 @@ function draw(cs: CanvasState): void {
      * fill pattern */
     drawPolygon(ctx, cs.points, cs.errorFillPattern);
   } else {
-    switch(cs.overlayMode) {
+    switch(cs.displaySettings.overlayMode) {
       case OverlayMode.BORDER:
         drawBorder(cs, cs.darkColor, cs.gridLineColor);
       break;
@@ -403,9 +403,8 @@ export default function CalibrationCanvas({
   height,
   isCalibrating,
   unitOfMeasure,
-  transformSettings,
-  setTransformSettings,
-  overlayMode,
+  displaySettings,
+  setDisplaySettings,
 }: {
   className: string | undefined;
   points: Point[];
@@ -416,9 +415,8 @@ export default function CalibrationCanvas({
   height: number;
   isCalibrating: boolean;
   unitOfMeasure: string;
-  transformSettings: TransformSettings;
-  setTransformSettings: Dispatch<SetStateAction<TransformSettings>>;
-  overlayMode: OverlayMode;
+  displaySettings: DisplaySettings;
+  setDisplaySettings: Dispatch<SetStateAction<DisplaySettings>>;
 }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const patternRef = useRef<CanvasPattern | null>(null);
@@ -447,9 +445,9 @@ export default function CalibrationCanvas({
     var _colorMode;
     /* The order is important here. The colorModes should monotonically 
      * increase each time it changes */
-    if (transformSettings.inverted && transformSettings.isInvertedGreen) {
+    if (displaySettings.inverted && displaySettings.isInvertedGreen) {
       _colorMode = 1;
-    } else if (transformSettings.inverted) {
+    } else if (displaySettings.inverted) {
       _colorMode = 2;
     } else {
       _colorMode = 0;
@@ -459,7 +457,7 @@ export default function CalibrationCanvas({
     /* Initialize prevColorModeRef if needed */
     if (prevColorModeRef.current == null)
       prevColorModeRef.current = _colorMode;
-  },[transformSettings])
+  },[displaySettings])
 
 useEffect(() => {
     /* No colorMode set yet, nothing to do */
@@ -566,8 +564,7 @@ useEffect(() => {
           isPrecisionMovement,
           patternRef.current,
           transitionProgress,
-          transformSettings,
-          overlayMode,
+          displaySettings,
         )
         draw(cs);
       }
@@ -598,9 +595,8 @@ useEffect(() => {
     pointToModify,
     unitOfMeasure,
     transitionProgress,
-    transformSettings,
+    displaySettings,
     isPrecisionMovement,
-    overlayMode
   ]);
 
   function getShortestDistance(p: Point): number {
@@ -782,9 +778,9 @@ useEffect(() => {
       if (e.code === "Tab") {
         e.preventDefault();
         if (e.shiftKey) {
-          setTransformSettings({
-            ...transformSettings,
-            isFourCorners: !transformSettings.isFourCorners,
+          setDisplaySettings({
+            ...displaySettings,
+            isFourCorners: !displaySettings.isFourCorners,
           });
         } else {
           const newPointToModify =
@@ -803,10 +799,10 @@ useEffect(() => {
     },
     [
       pointToModify,
-      transformSettings,
+      displaySettings,
       setPointToModify,
       localPoints.length,
-      setTransformSettings,
+      setDisplaySettings,
     ],
   );
 

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -28,6 +28,7 @@ import InvertColorOffIcon from "@/_icons/invert-color-off-icon";
 import PdfIcon from "@/_icons/pdf-icon";
 import Rotate90DegreesCWIcon from "@/_icons/rotate-90-degrees-cw-icon";
 import { TransformSettings } from "@/_lib/transform-settings";
+import { DisplaySettings } from "@/_lib/display-settings";
 import { CM, IN } from "@/_lib/unit";
 import RecenterIcon from "@/_icons/recenter-icon";
 import Matrix from "ml-matrix";
@@ -67,9 +68,9 @@ export default function Header({
   setUnitOfMeasure,
   transformSettings,
   setTransformSettings,
+  displaySettings,
+  setDisplaySettings,
   pageCount,
-  overlayMode,
-  setOverlayMode,
   layers,
   showLayerMenu,
   setShowLayerMenu,
@@ -95,10 +96,10 @@ export default function Header({
   unitOfMeasure: string;
   setUnitOfMeasure: (newUnit: string) => void;
   transformSettings: TransformSettings;
-  setTransformSettings: (newTransformSettings: TransformSettings) => void;
+  setTransformSettings: Dispatch<SetStateAction<TransformSettings>>;
+  displaySettings: DisplaySettings;
+  setDisplaySettings: (newDisplaySettings: DisplaySettings) => void;
   pageCount: number;
-  overlayMode: OverlayMode;
-  setOverlayMode: Dispatch<SetStateAction<OverlayMode>>;
   layers: Map<string, Layer>;
   showLayerMenu: boolean;
   setShowLayerMenu: Dispatch<SetStateAction<boolean>>;
@@ -209,28 +210,28 @@ export default function Header({
                   onClick={(e) => {
                     let newInverted;
                     let newIsGreenInverted;
-                    if (!transformSettings.inverted) {
+                    if (!displaySettings.inverted) {
                       newInverted = true;
                       newIsGreenInverted = true;
-                    } else if (transformSettings.isInvertedGreen) {
+                    } else if (displaySettings.isInvertedGreen) {
                       newInverted = true;
                       newIsGreenInverted = false;
                     } else {
                       newInverted = false;
                       newIsGreenInverted = false;
                     }
-                    setTransformSettings({
-                      ...transformSettings,
+                    setDisplaySettings({
+                      ...displaySettings,
                       inverted: newInverted,
                       isInvertedGreen: newIsGreenInverted,
                     });
-                    setInvertOpen(!transformSettings.inverted);
+                    setInvertOpen(!displaySettings.inverted);
                   }}
                 >
-                  {transformSettings.inverted ? (
+                  {displaySettings.inverted ? (
                     <InvertColorIcon
                       fill={
-                        transformSettings.isInvertedGreen
+                        displaySettings.isInvertedGreen
                           ? "#32CD32"
                           : "currentColor"
                       }
@@ -246,20 +247,20 @@ export default function Header({
           <div className={`flex items-center gap-2 ${visible(isCalibrating)}`}>
             <Tooltip
               description={
-                transformSettings.isFourCorners
+                displaySettings.isFourCorners
                   ? t("fourCornersOff")
                   : t("fourCornersOn")
               }
             >
               <IconButton
                 onClick={() =>
-                  setTransformSettings({
-                    ...transformSettings,
-                    isFourCorners: !transformSettings.isFourCorners,
+                  setDisplaySettings({
+                    ...displaySettings,
+                    isFourCorners: !displaySettings.isFourCorners,
                   })
                 }
               >
-                {transformSettings.isFourCorners ? (
+                {displaySettings.isFourCorners ? (
                   <FourCorners ariaLabel={t("fourCornersOn")} />
                 ) : (
                   <FourCornersOff ariaLabel={t("fourCornersOff")} />
@@ -337,8 +338,13 @@ export default function Header({
               </div>
             </Tooltip>
             <DropdownIconButton
-              selection={overlayMode}
-              setSelection={setOverlayMode}
+              selection={displaySettings.overlayMode}
+              setSelection={(newOverlayMode)=>{
+                setDisplaySettings({
+                  ...displaySettings,
+                  overlayMode: newOverlayMode,
+                });
+              }}
               description={t("overlayMode")}
               options={overlayOptions}
             />

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -120,17 +120,12 @@ export default function Header({
 
   function handleRecenter() {
     if (transformSettings.matrix !== null) {
-      const ptDensity = getPtDensity(unitOfMeasure);
-      const pdfPixels = 72;
-      const layoutPtDensity = 96;
-      let tx = ((+width * ptDensity) / 2)
-        - ((layoutWidth * layoutPtDensity / pdfPixels) / 2);
-      let ty = ((+height * ptDensity) / 2)
-        - ((layoutHeight * layoutPtDensity / pdfPixels) / 2);
+      let tx = +width / 2;
+      let ty = +height / 2;
       
-      const m = translate({ x: tx/ptDensity, y: ty/ptDensity});
+      const m = translate({ x: tx, y: ty});
       const newTransformMatrix = overrideTranslationFromMatrix(
-        transformSettings.matrix, m)
+        transformSettings.matrix, m);
       setTransformSettings({
        ...transformSettings,
         matrix: newTransformMatrix,
@@ -378,7 +373,7 @@ export default function Header({
                 onClick={() =>
                   setTransformSettings({
                     ...transformSettings,
-                    matrix: rotateMatrixDeg(transformSettings.matrix, -90),
+                    matrix: rotateMatrixDeg(transformSettings.matrix, 90),
                   })
                 }
               >

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -121,10 +121,11 @@ export default function Header({
     if (transformSettings.matrix !== null) {
       const ptDensity = getPtDensity(unitOfMeasure);
       const pdfPixels = 72;
-      //const tx = (+width * pdfPixels) / 2 - layoutWidth / 2;
-      //const ty = (+height * pdfPixels) / 2 - layoutHeight / 2;
-      const tx = ((+width * ptDensity) / 2);// 
-      const ty = ((+height * ptDensity) / 2);// - (layoutHeight/2);
+      const layoutPtDensity = 96;
+      let tx = ((+width * ptDensity) / 2)
+        - ((layoutWidth * layoutPtDensity / pdfPixels) / 2);
+      let ty = ((+height * ptDensity) / 2)
+        - ((layoutHeight * layoutPtDensity / pdfPixels) / 2);
       
       const m = translate({ x: tx/ptDensity, y: ty/ptDensity});
       const newTransformMatrix = overrideTranslationFromMatrix(

--- a/app/_components/pdf-viewer.tsx
+++ b/app/_components/pdf-viewer.tsx
@@ -36,7 +36,7 @@ export default function PdfViewer({
   setLayoutHeight,
   pageCount,
   layers,
-  setLocalTransform,
+  onDocumentLoad,
   calibrationTransform,
   lineThickness,
   columnCount,
@@ -50,7 +50,7 @@ export default function PdfViewer({
   setLayoutHeight: Dispatch<SetStateAction<number>>;
   pageCount: number;
   layers: Map<string, Layer>;
-  setLocalTransform: Dispatch<SetStateAction<Matrix>>;
+  onDocumentLoad: () => void;
   calibrationTransform: Matrix;
   lineThickness: number;
   columnCount: string;
@@ -59,12 +59,11 @@ export default function PdfViewer({
 }) {
   const [pageWidth, setPageWidth] = useState<number>(0);
   const [pageHeight, setPageHeight] = useState<number>(0);
-
   function onDocumentLoadSuccess(docProxy: PDFDocumentProxy) {
     setPageCount(docProxy.numPages);
     setLayers(new Map());
-    // reset local transform
-    setLocalTransform(calibrationTransform);
+    /* Call document load callback */
+    onDocumentLoad();
   }
 
   function onPageLoadSuccess(pdfProxy: PDFPageProxy) {

--- a/app/_hooks/useProgArrowKeyToMatrix.ts
+++ b/app/_hooks/useProgArrowKeyToMatrix.ts
@@ -4,34 +4,34 @@ import { translate } from "@/_lib/geometry";
 import { useEffect, useMemo, useState } from "react";
 import { Matrix } from "ml-matrix";
 
-export default function useProgArrowKeyToMatrix(active: boolean) {
-  const [offset, setOffset] = useState<Point>({ x: 0, y: 0 });
-  const translation: Matrix = useMemo(() => {
-    return translate(offset);
-  }, [offset]);
-
+export default function useProgArrowKeyToMatrix(
+  active: boolean,
+  scale: number,
+  applyChange: (matrix: Matrix) => void,
+  ) {
+  const PIXEL_LIST = [1, 10, 20, 100];
   function moveWithArrowKey(key: string, px: number) {
     let newOffset: Point = { x: 0, y: 0 };
+    const dist = px*scale;
     switch (key) {
       case "ArrowUp":
-        newOffset = applyOffset(offset, { y: -px, x: 0 });
+        newOffset = { y: -dist, x: 0 };
         break;
       case "ArrowDown":
-        newOffset = applyOffset(offset, { y: px, x: 0 });
+        newOffset = { y: dist, x: 0 };
         break;
       case "ArrowLeft":
-        newOffset = applyOffset(offset, { y: 0, x: -px });
+        newOffset = { y: 0, x: -dist };
         break;
       case "ArrowRight":
-        newOffset = applyOffset(offset, { y: 0, x: px });
+        newOffset = { y: 0, x: dist };
         break;
       default:
         break;
     }
-    setOffset(newOffset);
+    const m = translate(newOffset);
+    applyChange(m);
   }
 
-  useProgArrowKeyHandler(moveWithArrowKey, active);
-
-  return translation;
+  useProgArrowKeyHandler(moveWithArrowKey, active, PIXEL_LIST);
 }

--- a/app/_lib/display-settings.ts
+++ b/app/_lib/display-settings.ts
@@ -1,0 +1,17 @@
+import { OverlayMode } from "@/_lib/drawing";
+
+export interface DisplaySettings {
+  inverted: boolean;
+  isInvertedGreen: boolean;
+  isFourCorners: boolean;
+  overlayMode: OverlayMode;
+}
+
+export function getDefaultDisplaySettings() {
+  return {
+    inverted: false,
+    isInvertedGreen: false,
+    isFourCorners: true,
+    overlayMode: OverlayMode.BORDER
+  };
+}

--- a/app/_lib/drawing.ts
+++ b/app/_lib/drawing.ts
@@ -1,7 +1,7 @@
 import { getPtDensity } from "@/_lib/unit";
 import Matrix from "ml-matrix";
 import { Point } from "@/_lib/point";
-import { TransformSettings } from "@/_lib/transform-settings";
+import { DisplaySettings } from "@/_lib/display-settings";
 import {
   checkIsConcave
 } from "@/_lib/geometry";
@@ -33,8 +33,7 @@ export class CanvasState {
     public isPrecisionMovement: boolean,
     public errorFillPattern: CanvasPattern,
     public transitionProgress: number,
-    public transformSettings: TransformSettings,
-    public overlayMode: OverlayMode
+    public displaySettings: DisplaySettings,
   ) {
     this.isConcave = checkIsConcave(this.points);
     this.ptDensity = getPtDensity(unitOfMeasure);

--- a/app/_lib/geometry.ts
+++ b/app/_lib/geometry.ts
@@ -320,6 +320,16 @@ export function extractTranslationMatrix(matrix: Matrix): Matrix {
   ]);
 }
 
+/* Scale only the translation portion of the transformation matrix */
+export function scaleMatrixTranslation(matrix: Matrix, scale: number): Matrix {
+  const tx = matrix.get(0, 2);
+  const ty = matrix.get(1, 2);
+  const newMatrix = matrix.clone();
+  newMatrix.set(0, 2, tx * scale);
+  newMatrix.set(1, 2, ty * scale);
+  return newMatrix;
+}
+
 /* Extracts only the rotation and scale portion of the transformation matrix */
 export function extractRotationScaleMatrix(matrix: Matrix): Matrix {
   const newMatrix = matrix.clone();

--- a/app/_lib/transform-settings.ts
+++ b/app/_lib/transform-settings.ts
@@ -1,8 +1,8 @@
 import { Point } from "@/_lib/point";
+import Matrix from "ml-matrix";
 
 export interface TransformSettings {
-  scale: Point;
-  degrees: number;
+  matrix: Matrix;
   inverted: boolean;
   isInvertedGreen: boolean;
   isFourCorners: boolean;
@@ -10,10 +10,9 @@ export interface TransformSettings {
 
 export function getDefaultTransforms() {
   return {
-    degrees: 0,
-    scale: { x: 1, y: 1 },
     inverted: false,
     isInvertedGreen: false,
     isFourCorners: true,
+    matrix: Matrix.identity(3, 3),
   };
 }

--- a/app/_lib/transform-settings.ts
+++ b/app/_lib/transform-settings.ts
@@ -1,18 +1,11 @@
-import { Point } from "@/_lib/point";
 import Matrix from "ml-matrix";
 
 export interface TransformSettings {
   matrix: Matrix;
-  inverted: boolean;
-  isInvertedGreen: boolean;
-  isFourCorners: boolean;
 }
 
 export function getDefaultTransforms() {
   return {
-    inverted: false,
-    isInvertedGreen: false,
-    isFourCorners: true,
     matrix: Matrix.identity(3, 3),
   };
 }


### PR DESCRIPTION
Hear me out...

In my opinion, all transformations applied to the PDF by tools (like rotate, flip, etc) should be applied to a single transformation matrix. The downside of this is that you are unable to completely disambiguate the transforms that are being applied to the PDF. This means you cannot determine things like its absolute mirror state (I could be mistaken about this, but from my testing it doesn't work). I've change the two state mirror buttons to single state. You *can* still determine things like it's position, rotation, and scale from the matrix.

This have a lot of benefits:
- Calculating the final transform is simple. Adding more tools doesn't change the calculation.
- Rotation button works as expected. Before, the pattern would be rotated anti-clockwise if it was mirrored.
- Adding more transformation tools will be much easier.
- If we implement history we most likely only need to track a single matrix

The TransformSettings.matrix is in unitsOfMeasure. This should make it straightforward to apply exact translations to it for future tools like grid snapping and "translate by".

A nice little bonus of this implementation is that the position of the PDF doesn't get reset if the calibration is modified, and recentering works properly now (it was a little off before).

Let me know what you think of this change.