### PR TITLE
Added eslint rules to prevent tailing whitespaces, tabs, and incorrect indentation.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,18 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "no-trailing-spaces": "error",
+    "@typescript-eslint/indent": ["error", 2],
+    "no-tabs": "error",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unused-vars":"warn",
+    "@typescript-eslint/ban-types":"off"
+  }
 }

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -27,7 +27,7 @@ import {
 import {
   getDefaultDisplaySettings,
   DisplaySettings,
-	OverlaySettings
+  OverlaySettings
 } from "@/_lib/display-settings";
 import { CM, IN, getPtDensity } from "@/_lib/unit";
 import { Layer } from "@/_lib/layer";
@@ -109,23 +109,23 @@ export default function Page() {
 
   function resetTransformMatrix() {
     /* Resets and recenters the PDF */
-    let newTransformMatrix = Matrix.identity(3,3);
+    const newTransformMatrix = Matrix.identity(3,3);
     let tx = 0;
     let ty = 0;
 
     const scale = getPtDensity(unitOfMeasure) * .75;
-		const pdfWidth = layoutWidth / scale;
-		const pdfHeight = layoutHeight / scale;
-		
-		/* If pdf exceeds the width/height of the calibration
-			 align it to left/top */
-		if (pdfWidth > +width){
-			tx = (pdfWidth-(+width)) * 0.5;
-		}
-		if (pdfHeight > +height){
-			ty = (pdfHeight-(+height)) * 0.5;
-		}
-		
+    const pdfWidth = layoutWidth / scale;
+    const pdfHeight = layoutHeight / scale;
+
+    /* If pdf exceeds the width/height of the calibration
+       align it to left/top */
+    if (pdfWidth > +width){
+      tx = (pdfWidth-(+width)) * 0.5;
+    }
+    if (pdfHeight > +height){
+      ty = (pdfHeight-(+height)) * 0.5;
+    }
+
     const m = translate({ x: tx, y: ty});
     const recenteredMatrix = overrideTranslationFromMatrix(
       newTransformMatrix,
@@ -242,7 +242,7 @@ export default function Page() {
 
       const defaultDS = getDefaultDisplaySettings();
 
-      newDisplaySettings.overlay = localSettings.overlay !== undefined 
+      newDisplaySettings.overlay = localSettings.overlay !== undefined
         ? localSettings.overlay : defaultDS.overlay;
       newDisplaySettings.inverted = localSettings.inverted !== undefined
         ? localSettings.inverted : defaultDS.inverted;
@@ -286,7 +286,7 @@ export default function Page() {
   /* Update the pdfWidth and pdfHeight when it changes */
   useEffect(() => {
     const observer = new ResizeObserver((entries) => {
-      for (let entry of entries) {
+      for (const entry of entries) {
         const { width, height } = entry.contentRect;
         /* Only trigger if the dimension is non-zero
          * and different that the current dimension */
@@ -315,8 +315,8 @@ export default function Page() {
     const w = Number(width);
     const h = Number(height);
     if (points && points.length === maxPoints) {
-      let m = getPerspectiveTransformFromPoints(points, w, h, ptDensity, true);
-      let n = getPerspectiveTransformFromPoints(points, w, h, ptDensity, false);
+      const m = getPerspectiveTransformFromPoints(points, w, h, ptDensity, true);
+      const n = getPerspectiveTransformFromPoints(points, w, h, ptDensity, false);
       setPerspective(m);
       setLocalTransform(n);
       setCalibrationTransform(n);

--- a/app/[locale]/global-error.tsx
+++ b/app/[locale]/global-error.tsx
@@ -1,5 +1,5 @@
 'use client'
- 
+
 export default function GlobalError({
   error,
 }: {

--- a/app/_components/buttons/dropdown-checkbox-icon-button.tsx
+++ b/app/_components/buttons/dropdown-checkbox-icon-button.tsx
@@ -47,22 +47,22 @@ export function DropdownCheckboxIconButton({
   }, [containerRef]);
 
   const updateOption = (key: string): void => {
-		const updatedOptions = {
-			...options,
-			[key]: {
-				...options[key],
-				selected: !options[key].selected,
-			},
-		};
+    const updatedOptions = {
+      ...options,
+      [key]: {
+        ...options[key],
+        selected: !options[key].selected,
+      },
+    };
 
-		setSelectedOptions(
-			Object.fromEntries(
-				Object.entries(updatedOptions).map(([key, option]) => [key, option.selected])
-			)
-		);
+    setSelectedOptions(
+      Object.fromEntries(
+        Object.entries(updatedOptions).map(([key, option]) => [key, option.selected])
+      )
+    );
   }
-	
-	const disabled = options[disableOptionKey].selected;
+
+  const disabled = options[disableOptionKey].selected;
 
   return (
     <div
@@ -78,7 +78,7 @@ export function DropdownCheckboxIconButton({
           aria-haspopup="true"
           aria-expanded={isOpen}
         >
-          {disabled ? disabledIcon : icon } 
+          {disabled ? disabledIcon : icon }
         </IconButton>
       </Tooltip>
       <div
@@ -92,17 +92,17 @@ export function DropdownCheckboxIconButton({
             className={`flex cursor-pointer items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 rounded-md`}
             role="menuitem"
             tabIndex={0}
-						onClick={() => updateOption(key)}
-						disabled = {disabled && key != disableOptionKey}
+            onClick={() => updateOption(key)}
+            disabled = {disabled && key != disableOptionKey}
           >
             <span className="mr-3">{option.icon}</span>
-						<input
-							tabIndex={-1}
-							type="checkbox"
-							checked={option.selected}
-							className="form-checkbox cursor-pointer accent-purple-600 h-4 w-4 mr-3"
-							disabled = {disabled && key != disableOptionKey}
-						/>
+            <input
+              tabIndex={-1}
+              type="checkbox"
+              checked={option.selected}
+              className="form-checkbox cursor-pointer accent-purple-600 h-4 w-4 mr-3"
+              disabled = {disabled && key != disableOptionKey}
+            />
             <span className="select-none">{option.text}</span>
           </button>
         ))}

--- a/app/_components/calibration-canvas.tsx
+++ b/app/_components/calibration-canvas.tsx
@@ -136,25 +136,25 @@ function draw(cs: CanvasState): void {
      * fill pattern */
     drawPolygon(ctx, cs.points, cs.errorFillPattern);
   } else {
-		/* Draw projection page */
-		if (!cs.displaySettings.overlay.disabled)
-			drawOverlays(cs)
+    /* Draw projection page */
+    if (!cs.displaySettings.overlay.disabled)
+      drawOverlays(cs)
   }
 }
 
 function drawOverlays(cs: CanvasState) {
-	const o = cs.displaySettings.overlay;
-	const ctx = cs.ctx;
-	if (o.grid){
-		ctx.strokeStyle = cs.projectionGridLineColor
-		drawGrid(cs, 8, [1]) 
-	}
-	if (o.border)
-		drawBorder(cs, cs.darkColor, cs.gridLineColor);
-	if (o.paper)
-		drawPaperSheet(cs);
-	if (o.fliplines)
-		drawCenterLines(cs);
+  const o = cs.displaySettings.overlay;
+  const ctx = cs.ctx;
+  if (o.grid){
+    ctx.strokeStyle = cs.projectionGridLineColor
+    drawGrid(cs, 8, [1])
+  }
+  if (o.border)
+    drawBorder(cs, cs.darkColor, cs.gridLineColor);
+  if (o.paper)
+    drawPaperSheet(cs);
+  if (o.fliplines)
+    drawCenterLines(cs);
 }
 
 function drawCenterLines(cs: CanvasState) {
@@ -208,7 +208,7 @@ function drawCenterLines(cs: CanvasState) {
 
   const lineWidth = 3;
   ctx.setLineDash([5, 1]);
-  ctx.strokeStyle = cs.projectionGridLineColor; 
+  ctx.strokeStyle = cs.projectionGridLineColor;
 
   drawLine(ctx, projectedY[0], projectedY[1], lineWidth);
   ctx.stroke();
@@ -438,7 +438,7 @@ function drawPolygon(
   strokeStyle?: string | null,
 ): void {
   ctx.beginPath();
-  for (let p of points) {
+  for (const p of points) {
     ctx.lineTo(p.x, p.y);
   }
   ctx.closePath();
@@ -507,7 +507,7 @@ export default function CalibrationCanvas({
   const maxColorMode = 2;
 
   useEffect(() => {
-    var _colorMode;
+    let _colorMode;
     /* The order is important here. The colorModes should monotonically
      * increase each time it changes */
     if (displaySettings.inverted && displaySettings.isInvertedGreen) {
@@ -608,7 +608,7 @@ export default function CalibrationCanvas({
     ) {
 
       /* All drawing is done in unitsOfMeasure, ptDensity = 1.0 */
-      let perspective_mtx = getPerspectiveTransformFromPoints(
+      const perspective_mtx = getPerspectiveTransformFromPoints(
         localPoints,
         width,
         height,
@@ -622,7 +622,7 @@ export default function CalibrationCanvas({
       if (ctx !== null) {
         ctx.canvas.width = window.innerWidth;
         ctx.canvas.height = window.innerHeight;
-        let cs = new CanvasState(
+        const cs = new CanvasState(
           ctx,
           { x: 0, y: 0 },
           localPoints,

--- a/app/_components/draggable.tsx
+++ b/app/_components/draggable.tsx
@@ -51,7 +51,7 @@ export default function Draggable({
       if (e.key === AXIS_LOCK_KEYBIND) {
         e.preventDefault();
         setIsAxisLocked(true);
-      } 
+      }
     },
     [
       setIsAxisLocked,
@@ -63,7 +63,7 @@ export default function Draggable({
       if (e.key === AXIS_LOCK_KEYBIND) {
         e.preventDefault();
         setIsAxisLocked(false);
-      } 
+      }
     },
     [
       setIsAxisLocked,
@@ -110,9 +110,9 @@ export default function Draggable({
 
   function toSingleAxisVector(vec: Point): Point{
     if (Math.abs(vec.x) > Math.abs(vec.y)){
-      return {x: vec.x, y:0} 
+      return {x: vec.x, y:0}
     } else {
-      return {x: 0, y:vec.y} 
+      return {x: 0, y:vec.y}
     }
   }
 
@@ -129,14 +129,14 @@ export default function Draggable({
       const m = translate(vec);
       const newTransformMatrix = m.mmul(transformStart);
       setTransformSettings({
-       ...transformSettings,
+        ...transformSettings,
         matrix: newTransformMatrix,
       })
     }
   }
 
   function handleOnStart(p: Point): void {
-    var pt = transformPoint(p, perspective);
+    const pt = transformPoint(p, perspective);
     setDragStart(pt);
     setTransformStart(transformSettings.matrix.clone());
   }

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -122,9 +122,9 @@ export default function Header({
 
   function handleRecenter() {
     if (transformSettings.matrix !== null) {
-      let tx = 0;
-      let ty = 0;
-      
+      const tx = 0;
+      const ty = 0;
+
       const m = translate({ x: tx, y: ty});
       const newTransformMatrix = overrideTranslationFromMatrix(
         transformSettings.matrix,
@@ -356,10 +356,10 @@ export default function Header({
               setSelectedOptions={(options) => {
                 setDisplaySettings({
                   ...displaySettings,
-									overlay: {
-										...displaySettings.overlay,
-										...options
-									},
+                  overlay: {
+                    ...displaySettings.overlay,
+                    ...options
+                  },
                 });
               }}
             />
@@ -367,10 +367,10 @@ export default function Header({
             <Tooltip description={t("flipHorizontal")}>
               <IconButton
                 onClick={() => {
-									setTransformSettings({
-										...transformSettings,
-										matrix: flipMatrixHorizontally(transformSettings.matrix, 0),
-									})
+                  setTransformSettings({
+                    ...transformSettings,
+                    matrix: flipMatrixHorizontally(transformSettings.matrix, 0),
+                  })
                 }}
               >
                 <FlipVerticalIcon ariaLabel={t("flipHorizontal")} />
@@ -379,10 +379,10 @@ export default function Header({
             <Tooltip description={t("flipVertical")}>
               <IconButton
                 onClick={() => {
-									setTransformSettings({
-										...transformSettings,
-										matrix: flipMatrixVertically(transformSettings.matrix, 0),
-									})
+                  setTransformSettings({
+                    ...transformSettings,
+                    matrix: flipMatrixVertically(transformSettings.matrix, 0),
+                  })
                 }}
               >
                 <FlipHorizontalIcon ariaLabel={t("flipVertical")} />

--- a/app/_components/language-switcher.tsx
+++ b/app/_components/language-switcher.tsx
@@ -5,7 +5,7 @@ import InlineSelect from "@/_components/inline-select";
 
 interface LanguageSwitcherProps {
   ariaLabel?: string;
-  className?: string; 
+  className?: string;
 }
 
 const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ ariaLabel, className }) => {
@@ -34,8 +34,8 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ ariaLabel, classNam
         name="change_language"
         value={locale}
         options={Object.entries(locale_data).map(([key, {flag, name}]) => ({
-            value: key,
-            label: flag + " " + name
+          value: key,
+          label: flag + " " + name
         }))}
       />
     </div>

--- a/app/_components/measure-canvas.tsx
+++ b/app/_components/measure-canvas.tsx
@@ -66,11 +66,11 @@ export default function MeasureCanvas({
         if (startPoint && movingPoint) {
           let dest = axisConstrained
             ? constrainInSpace(
-                movingPoint,
-                startPoint,
-                perspective,
-                calibrationTransform,
-              )
+              movingPoint,
+              startPoint,
+              perspective,
+              calibrationTransform,
+            )
             : movingPoint;
           if (endPoint) {
             dest = endPoint;

--- a/app/_components/pdf-custom-renderer.tsx
+++ b/app/_components/pdf-custom-renderer.tsx
@@ -15,7 +15,7 @@ function erodeImageData(imageData: ImageData, output: ImageData) {
   const erodedData = output.data;
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      let index = (y * width + x) * 4;
+      const index = (y * width + x) * 4;
       for (let i = 0; i < 3; i++) {
         erodedData[index + i] = erodeAtIndex(
           imageData,
@@ -45,25 +45,25 @@ function erodeAtIndex(
     return 0;
   }
   if (x > 0) {
-    let n = data[index - 4];
+    const n = data[index - 4];
     if (n < c) {
       c = n;
     }
   }
   if (x < width - 1) {
-    let n = data[index + 4];
+    const n = data[index + 4];
     if (n < c) {
       c = n;
     }
   }
   if (y > 0) {
-    let n = data[index - width * 4];
+    const n = data[index - width * 4];
     if (n < c) {
       c = n;
     }
   }
   if (y < height - 1) {
-    let n = data[index + width * 4];
+    const n = data[index + width * 4];
     if (n < c) {
       c = n;
     }
@@ -138,7 +138,7 @@ export default function CustomRenderer(
             setLayers(l);
           });
         } else {
-          for (let entry of layers) {
+          for (const entry of layers) {
             const layer = entry[1];
             for (let i = 0; i < layer.ids.length; i += 1) {
               optionalContentConfig.setVisibility(layer.ids[i], layer.visible);
@@ -167,7 +167,7 @@ export default function CustomRenderer(
         if (erosions === 0) {
           return;
         }
-        let ctx = renderContext.canvasContext;
+        const ctx = renderContext.canvasContext;
         let imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
         const erodedData = new Uint8ClampedArray(imageData.data.length);
         let output = new ImageData(

--- a/app/_hooks/useProgArrowKeyToMatrix.ts
+++ b/app/_hooks/useProgArrowKeyToMatrix.ts
@@ -8,7 +8,7 @@ export default function useProgArrowKeyToMatrix(
   active: boolean,
   scale: number,
   applyChange: (matrix: Matrix) => void,
-  ) {
+) {
   const PIXEL_LIST = [1, 10, 20, 100];
   function moveWithArrowKey(key: string, px: number) {
     let newOffset: Point = { x: 0, y: 0 };

--- a/app/_lib/drawing.ts
+++ b/app/_lib/drawing.ts
@@ -11,7 +11,7 @@ export class CanvasState {
 
   lightColor: string = "#fff";
   darkColor: string = "#000";
-  greenColor: string = "#32CD32" 
+  greenColor: string = "#32CD32"
   bgColor: string = "#fff";
   fillColor: string = "#000";
   gridLineColor: string = "#fff";
@@ -51,7 +51,7 @@ export function createCheckerboardPattern(
   size: number = 3,
   color1: string = "black",
   color2: string = "#CCC"
-  ): CanvasPattern {
+): CanvasPattern {
   /* We first create a new canvas on which to draw the pattern */
   const patternCanvas = document.createElement('canvas');
   try {
@@ -60,7 +60,7 @@ export function createCheckerboardPattern(
     if (!patternCtx) {
       throw new Error('Failed to get 2D context from pattern canvas');
     }
-  
+
     /* Integer which defines the size of a checkboard square (in pixels) */
     size = Math.round(size)
 
@@ -93,25 +93,25 @@ export function createCheckerboardPattern(
  * "value" should be a number between zero and len(colors). */
 export function interpolateColorRing(colors: string[], value: number, useEaseInOut: boolean = true): string {
   const len = colors.length;
-  
+
   // Normalize the value to be between 0 and len
   const normalizedValue = ((value % len) + len) % len;
-  
+
   // Find the indices of the two colors to interpolate between
   const startIndex = Math.floor(normalizedValue);
   const endIndex = (startIndex + 1) % len;
-  
+
   // Calculate the portion for interpolation
   let portion = normalizedValue - startIndex;
 
   // Apply the easing function if set
   if (useEaseInOut) {
     portion = easeInOut(portion);
-  }  
+  }
   // Get the start and end colors
   const startColor = colors[startIndex];
   const endColor = colors[endIndex];
-  
+
   // Interpolate between the start and end colors using the interpolateColors function
   return interpolateColor(startColor, endColor, portion);
 }
@@ -136,11 +136,11 @@ export function cubicBezierTiming(t: number, x1?: number, y1?: number, x2?: numb
   const sampleCurveX = (t: number): number => {
     return ((ax * t + bx) * t + cx) * t;
   }
-  
+
   const sampleCurveDerivativeX = (t: number): number => {
     return (3 * ax * t + 2 * bx) * t + cx;
   }
-  
+
   const solveCurveX = (x: number): number => {
     // Set Precision
     const epsilon = 1e-6;

--- a/app/_lib/geometry.ts
+++ b/app/_lib/geometry.ts
@@ -121,7 +121,7 @@ export function getPerspectiveTransform(
   const X = x.getColumn(0);
   X.push(1);
 
-  var s = Matrix.from1DArray(3, 3, X);
+  const s = Matrix.from1DArray(3, 3, X);
   return s;
 }
 
@@ -160,12 +160,12 @@ export function transformPoints(points: Point[], m: Matrix): Point[] {
 }
 
 export function transformPoint(p: Point, mm: Matrix): Point {
-  let m = mm.to1DArray();
-  var w = p.x * m[6] + p.y * m[7] + m[8];
+  const m = mm.to1DArray();
+  let w = p.x * m[6] + p.y * m[7] + m[8];
   w = 1 / w;
-  let ox = (p.x * m[0] + p.y * m[1] + m[2]) * w;
-  let oy = (p.x * m[3] + p.y * m[4] + m[5]) * w;
-  let result = { x: ox, y: oy };
+  const ox = (p.x * m[0] + p.y * m[1] + m[2]) * w;
+  const oy = (p.x * m[3] + p.y * m[4] + m[5]) * w;
+  const result = { x: ox, y: oy };
   return result;
 }
 
@@ -178,31 +178,31 @@ export function scale(s: number): Matrix {
 }
 
 export function rotateMatrixDeg(matrix: Matrix, angleDegrees: number, center?: Point): Matrix {
-	/* If no center of rotation provided, use the center of the object */
-	if (center === undefined)
-		center = { x: matrix.get(0,2), y: matrix.get(1,2) }
+  /* If no center of rotation provided, use the center of the object */
+  if (center === undefined)
+    center = { x: matrix.get(0,2), y: matrix.get(1,2) }
 
   /* Create the rotation matrix */
   const angleRadians = (angleDegrees * Math.PI) / 180;
   const cosAngle = Math.cos(angleRadians);
   const sinAngle = Math.sin(angleRadians);
-  let rotationMatrix = new Matrix([
+  const rotationMatrix = new Matrix([
     [cosAngle, -sinAngle, 0],
     [sinAngle, cosAngle, 0],
     [0, 0, 1],
   ]);
 
   /* Create the translation matrices for shifting the center of rotation */
-  let translationToOrigin = new Matrix([
-      [1, 0, -center.x],
-      [0, 1, -center.y],
-      [0, 0, 1],
-    ]);
-  let translationBack = new Matrix([
-      [1, 0, center.x],
-      [0, 1, center.y],
-      [0, 0, 1],
-    ]);
+  const translationToOrigin = new Matrix([
+    [1, 0, -center.x],
+    [0, 1, -center.y],
+    [0, 0, 1],
+  ]);
+  const translationBack = new Matrix([
+    [1, 0, center.x],
+    [0, 1, center.y],
+    [0, 0, 1],
+  ]);
 
   /* Apply the rotation around the specified center */
   const rotatedMatrix = translationBack
@@ -236,7 +236,7 @@ export class DecomposedTransform {
   formatCssNoTranslation(): string {
     return `matrix(${this.a}, ${this.b}, ${this.c}, ${this.d}, 0, 0)`;
   }
-  
+
 }
 
 export function decomposeTransformMatrix(matrix: Matrix): DecomposedTransform {
@@ -281,7 +281,7 @@ export function flipMatrixVertically(matrix: Matrix, yintercept?: number): Matri
     [0, -1, 2*k],
     [0, 0, 1]
   ]);
-    
+
   return flipMatrix.mmul(matrix)
 }
 
@@ -289,7 +289,7 @@ export function flipMatrixVertically(matrix: Matrix, yintercept?: number): Matri
 export function flipMatrixHorizontally(matrix: Matrix, xintercept?: number): Matrix {
   const k = xintercept !== undefined ? xintercept : matrix.get(0,2);
   // Create a flip matrix to perform horizontal flipping
-  let flipMatrix = new Matrix([
+  const flipMatrix = new Matrix([
     [-1, 0, k*2],
     [0, 1, 0],
     [0, 0, 1]
@@ -299,12 +299,12 @@ export function flipMatrixHorizontally(matrix: Matrix, xintercept?: number): Mat
 
 export function isMatrixFlippedVertically(matrix: Matrix): boolean {
   const decomposedMatrix = decomposeTransformMatrix(matrix)
-  return decomposedMatrix.scale.y < 0; 
+  return decomposedMatrix.scale.y < 0;
 }
 
 export function isMatrixFlippedHorizontally(matrix: Matrix): boolean {
   const decomposedMatrix = decomposeTransformMatrix(matrix)
-  return decomposedMatrix.scale.x < 0; 
+  return decomposedMatrix.scale.x < 0;
 }
 
 /* Overrides the translation component of destMatrix with the srcMatrix's */
@@ -312,7 +312,7 @@ export function overrideTranslationFromMatrix(destMatrix: Matrix, srcMatrix: Mat
   const tx = srcMatrix.get(0, 2);
   const ty = srcMatrix.get(1, 2);
 
-  let newMatrix = destMatrix.clone()
+  const newMatrix = destMatrix.clone()
   newMatrix.set(0, 2, tx);
   newMatrix.set(1, 2, ty);
 
@@ -355,7 +355,7 @@ export function extractRotationScaleMatrix(matrix: Matrix): Matrix {
  * @returns A css transfomr string
  */
 export function toMatrix3d(m: Matrix): string {
-  var r = m.clone();
+  let r = m.clone();
   // Make the 3x3 into 4x4 by inserting a z component in the 3rd column.
   r.addColumn(2, AbstractMatrix.zeros(1, 3));
   r.addRow(2, AbstractMatrix.from1DArray(1, 4, [0, 0, 1, 0]));
@@ -366,14 +366,14 @@ export function toMatrix3d(m: Matrix): string {
 }
 
 export function sqrdist(a: Point, b: Point): number {
-  let dx = a.x - b.x;
-  let dy = a.y - b.y;
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
   return dx * dx + dy * dy;
 }
 
 export function minIndex(a: number[]): number {
-  var min = 0;
-  for (var i = 1; i < a.length; i++) {
+  let min = 0;
+  for (let i = 1; i < a.length; i++) {
     if (a[i] < a[min]) {
       min = i;
     }

--- a/app/_lib/get-page-numbers.ts
+++ b/app/_lib/get-page-numbers.ts
@@ -1,7 +1,7 @@
 export function getPageNumbers(pageRange: string, pageCount: number): number[] {
   const ranges = pageRange.split(",");
   let pages = [];
-  for (let r of ranges) {
+  for (const r of ranges) {
     if (r.indexOf('-') < 0) {
       pages.push(Math.min(pageCount, Number(r)));
     } else {

--- a/app/_lib/key-code.ts
+++ b/app/_lib/key-code.ts
@@ -1,4 +1,4 @@
 export enum KeyCode {
- KeyM = 'KeyM',
- Escape = 'Escape',
+  KeyM = 'KeyM',
+  Escape = 'Escape',
 }

--- a/app/_lib/unit.ts
+++ b/app/_lib/unit.ts
@@ -2,6 +2,6 @@ export const { CM, IN } = { IN: 'IN', CM: 'CM' };
 
 export function getPtDensity(
   unitOfMeasure: string,
-  ): number {
-   return unitOfMeasure === CM ? 96 / 2.54 : 96;
+): number {
+  return unitOfMeasure === CM ? 96 / 2.54 : 96;
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.5.5",
+    "@typescript-eslint/eslint-plugin": "^7.4.0",
     "cypress": "^13.6.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1036,14 +1036,14 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@eslint-community/eslint-utils@^4.2.0":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
-"@eslint-community/regexpp@^4.6.1":
+"@eslint-community/regexpp@^4.5.1", "@eslint-community/regexpp@^4.6.1":
   version "4.10.0"
   resolved "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz"
   integrity sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==
@@ -1763,7 +1763,7 @@
     "@types/tough-cookie" "*"
     parse5 "^7.0.0"
 
-"@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8":
+"@types/json-schema@^7.0.12", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8":
   version "7.0.15"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
@@ -1832,6 +1832,11 @@
   resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz"
   integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
+"@types/semver@^7.5.0":
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
   resolved "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz"
@@ -1876,6 +1881,23 @@
   dependencies:
     "@types/node" "*"
 
+"@typescript-eslint/eslint-plugin@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.4.0.tgz#de61c3083842fc6ac889d2fc83c9a96b55ab8328"
+  integrity sha512-yHMQ/oFaM7HZdVrVm/M2WHaNPgyuJH4WelkSVEWSSsir34kxW2kDJCxlXRhhGWEsMN0WAW/vLpKfKVcm8k+MPw==
+  dependencies:
+    "@eslint-community/regexpp" "^4.5.1"
+    "@typescript-eslint/scope-manager" "7.4.0"
+    "@typescript-eslint/type-utils" "7.4.0"
+    "@typescript-eslint/utils" "7.4.0"
+    "@typescript-eslint/visitor-keys" "7.4.0"
+    debug "^4.3.4"
+    graphemer "^1.4.0"
+    ignore "^5.2.4"
+    natural-compare "^1.4.0"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
 "@typescript-eslint/parser@^5.4.2 || ^6.0.0":
   version "6.21.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz"
@@ -1895,10 +1917,33 @@
     "@typescript-eslint/types" "6.21.0"
     "@typescript-eslint/visitor-keys" "6.21.0"
 
+"@typescript-eslint/scope-manager@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz#acfc69261f10ece7bf7ece1734f1713392c3655f"
+  integrity sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==
+  dependencies:
+    "@typescript-eslint/types" "7.4.0"
+    "@typescript-eslint/visitor-keys" "7.4.0"
+
+"@typescript-eslint/type-utils@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-7.4.0.tgz#cfcaab21bcca441c57da5d3a1153555e39028cbd"
+  integrity sha512-247ETeHgr9WTRMqHbbQdzwzhuyaJ8dPTuyuUEMANqzMRB1rj/9qFIuIXK7l0FX9i9FXbHeBQl/4uz6mYuCE7Aw==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "7.4.0"
+    "@typescript-eslint/utils" "7.4.0"
+    debug "^4.3.4"
+    ts-api-utils "^1.0.1"
+
 "@typescript-eslint/types@6.21.0":
   version "6.21.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz"
   integrity sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==
+
+"@typescript-eslint/types@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.4.0.tgz#ee9dafa75c99eaee49de6dcc9348b45d354419b6"
+  integrity sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==
 
 "@typescript-eslint/typescript-estree@6.21.0":
   version "6.21.0"
@@ -1914,12 +1959,47 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
+"@typescript-eslint/typescript-estree@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz#12dbcb4624d952f72c10a9f4431284fca24624f4"
+  integrity sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==
+  dependencies:
+    "@typescript-eslint/types" "7.4.0"
+    "@typescript-eslint/visitor-keys" "7.4.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    minimatch "9.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
+"@typescript-eslint/utils@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-7.4.0.tgz#d889a0630cab88bddedaf7c845c64a00576257bd"
+  integrity sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@types/json-schema" "^7.0.12"
+    "@types/semver" "^7.5.0"
+    "@typescript-eslint/scope-manager" "7.4.0"
+    "@typescript-eslint/types" "7.4.0"
+    "@typescript-eslint/typescript-estree" "7.4.0"
+    semver "^7.5.4"
+
 "@typescript-eslint/visitor-keys@6.21.0":
   version "6.21.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz"
   integrity sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==
   dependencies:
     "@typescript-eslint/types" "6.21.0"
+    eslint-visitor-keys "^3.4.1"
+
+"@typescript-eslint/visitor-keys@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz#0c8ff2c1f8a6fe8d7d1a57ebbd4a638e86a60a94"
+  integrity sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==
+  dependencies:
+    "@typescript-eslint/types" "7.4.0"
     eslint-visitor-keys "^3.4.1"
 
 "@vercel/analytics@^1.1.3":
@@ -4187,7 +4267,7 @@ ieee754@^1.1.13:
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^5.2.0:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.1"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==


### PR DESCRIPTION
You can run yarn lint --fix to automatically fix most errors (except no-tabs, you can fix these errors by opening the file in vim and using :retab assuming your indentation is set up correctly).

How do y'all feel about adding more lint rules? I added some rules to let us get away with things like "any" and "Function". Unused vars are left as a warning, and this commit made no effort to fix them. If we decide that we like these lint rules, I'll go ahead and fix more of the unused vars warnings.

I mostly did this because I noticed that I've been using tabs instead of spaces because I messed up my vimrc on my home linux machine (oops!). This should help to keep the codebase a little cleaner (automagically).

There's apparently ways to set up your text editor to automatically run `yarn lint --fix` on save, which could be useful.   