### PR TITLE
Prepare for when the French translation is done - this adds support for French to the rest of the app.

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -20,7 +20,7 @@ import { IconButton } from "@/_components/buttons/icon-button";
 export default function Home() {
   const t = useTranslations("HomePage");
   const messages = useMessages() as IntlMessages;
-  const keys = Object.keys(messages.HomePage.resources.links);
+  const keys = Object.keys(messages.HomePage.resources.links ? messages.HomePage.resources.links : {});
 
   return (
     <main className="m-4">

--- a/app/_components/language-switcher.tsx
+++ b/app/_components/language-switcher.tsx
@@ -21,9 +21,10 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ ariaLabel, classNam
   // Language names are not translated because we want them to be the same always, regardless of the current language.
   const locale_data = {
     'de': { 'flag': '\uD83C\uDDE9\uD83C\uDDEA', 'name': "Deutsch" },  // DE flag for German
-    'da': { 'flag': '\uD83C\uDDE9\uD83C\uDDF0', 'name': "Danish" },  // DK flag for Danish
+    'da': { 'flag': '\uD83C\uDDE9\uD83C\uDDF0', 'name': "Dansk" },  // DK flag for Danish
     'nl': { 'flag': '\uD83C\uDDF3\uD83C\uDDF1', 'name': "Nederlands" },  // NL flag for Dutch
-    'en': { 'flag': '\uD83C\uDDFA\uD83C\uDDF8', 'name': "English" }  // US flag for English
+    'en': { 'flag': '\uD83C\uDDFA\uD83C\uDDF8', 'name': "English" },  // US flag for English
+    'fr': { 'flag': '\uD83C\uDDEB\uD83C\uDDF7', 'name': "Français" }  // FR flag for French
   };
 
   return (

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import createMiddleware from 'next-intl/middleware';
 
-export const locales = ['en', 'de', 'da', 'nl'];
+export const locales = ['en', 'de', 'da', 'nl', 'fr'];
  
 export default createMiddleware({
   // A list of all locales that are supported
@@ -13,5 +13,5 @@ export default createMiddleware({
 export const config = {
   // Match only internationalized pathnames
   // Match /calibrate for people who saved a link to /calibrate before internationalization was added
-  matcher: ['/', '/(da|de|en|nl)/:path*', '/calibrate']
+  matcher: ['/', '/(da|de|en|nl|fr)/:path*', '/calibrate']
 };


### PR DESCRIPTION
Also puts Danish as 'Dansk' into the language menu, to be consistent with the others and the idea behind how the drop down should work.