### PR TITLE
Added shift key modifier to arrow key movement

### DIFF
--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -254,8 +254,9 @@ export default function Page() {
     }
   }, []);
 
-  /* Scale of 1.0 would mean 1 in/cm per key press. Here it is 1/16th in/cm */
-  useProgArrowKeyToMatrix(!isCalibrating, 16.0, (matrix) => {
+  /* Scale of 1.0 would mean 1 in/cm per key press. Here it is 1/16th in or  1 mm */
+  const arrowKeyScale = unitOfMeasure == IN ? 16.0 : 10.0;
+  useProgArrowKeyToMatrix(!isCalibrating, arrowKeyScale, (matrix) => {
     const newTransformMatrix = matrix.mmul(transformSettings.matrix);
     setTransformSettings({
       ...transformSettings,

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -81,6 +81,7 @@ export default function Page() {
   const [lineThickness, setLineThickness] = useState<number>(0);
   const [measuring, setMeasuring] = useState<boolean>(false);
   const [gridSize, setGridSize] = useState<number>(16.0);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
 
   const [showStitchMenu, setShowStitchMenu] = useState<boolean>(false);
   const [pageRange, setPageRange] = useState<string>("");
@@ -412,6 +413,7 @@ export default function Page() {
             matrix={transformSettings.matrix}
             unitOfMeasure={unitOfMeasure}
             className={`z-30 ${visible(!isCalibrating)}`}
+            preventReset={isDragging}
           />
 
           <LayerMenu
@@ -472,6 +474,7 @@ export default function Page() {
             perspective={perspective}
             unitOfMeasure={unitOfMeasure}
             gridSize={gridSize}
+            setIsDragging={setIsDragging}
           >
             <div
               ref={pdfRef}

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -8,6 +8,7 @@ import CalibrationCanvas from "@/_components/calibration-canvas";
 import Draggable from "@/_components/draggable";
 import Header from "@/_components/header";
 import PDFViewer from "@/_components/pdf-viewer";
+import TransformMatrixDisplay from "@/_components/transform-matrix-display";
 import {
   getPerspectiveTransformFromPoints,
   toMatrix3d,
@@ -27,7 +28,7 @@ import {
 import {
   getDefaultDisplaySettings,
   DisplaySettings,
-	OverlaySettings
+  OverlaySettings
 } from "@/_lib/display-settings";
 import { CM, IN, getPtDensity } from "@/_lib/unit";
 import { Layer } from "@/_lib/layer";
@@ -114,18 +115,18 @@ export default function Page() {
     let ty = 0;
 
     const scale = getPtDensity(unitOfMeasure) * .75;
-		const pdfWidth = layoutWidth / scale;
-		const pdfHeight = layoutHeight / scale;
-		
-		/* If pdf exceeds the width/height of the calibration
-			 align it to left/top */
-		if (pdfWidth > +width){
-			tx = (pdfWidth-(+width)) * 0.5;
-		}
-		if (pdfHeight > +height){
-			ty = (pdfHeight-(+height)) * 0.5;
-		}
-		
+    const pdfWidth = layoutWidth / scale;
+    const pdfHeight = layoutHeight / scale;
+    
+    /* If pdf exceeds the width/height of the calibration
+       align it to left/top */
+    if (pdfWidth > +width){
+      tx = (pdfWidth-(+width)) * 0.5;
+    }
+    if (pdfHeight > +height){
+      ty = (pdfHeight-(+height)) * 0.5;
+    }
+    
     const m = translate({ x: tx, y: ty});
     const recenteredMatrix = overrideTranslationFromMatrix(
       newTransformMatrix,
@@ -401,6 +402,12 @@ export default function Page() {
             showStitchMenu={showStitchMenu}
             measuring={measuring}
             setMeasuring={setMeasuring}
+          />
+
+          <TransformMatrixDisplay
+            matrix={transformSettings.matrix}
+            unitOfMeasure={unitOfMeasure}
+            className={`z-30 ${visible(!isCalibrating)}`}
           />
 
           <LayerMenu

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -255,7 +255,7 @@ export default function Page() {
   }, []);
 
   /* Scale of 1.0 would mean 1 in/cm per key press. Here it is 1/16th in/cm */
-  useProgArrowKeyToMatrix(!isCalibrating, 1.0 / 16.0, (matrix) => {
+  useProgArrowKeyToMatrix(!isCalibrating, 16.0, (matrix) => {
     const newTransformMatrix = matrix.mmul(transformSettings.matrix);
     setTransformSettings({
       ...transformSettings,

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -75,9 +75,6 @@ export default function Header({
   displaySettings,
   setDisplaySettings,
   pageCount,
-  localTransform,
-  calibrationTransform,
-  setLocalTransform,
   layoutWidth,
   layoutHeight,
   setShowStitchMenu,
@@ -103,9 +100,6 @@ export default function Header({
   displaySettings: DisplaySettings;
   setDisplaySettings: (newDisplaySettings: DisplaySettings) => void;
   pageCount: number;
-  localTransform: Matrix;
-  calibrationTransform: Matrix;
-  setLocalTransform: Dispatch<SetStateAction<Matrix>>;
   layoutWidth: number;
   layoutHeight: number;
   lineThickness: number;

--- a/app/_components/measure-canvas.tsx
+++ b/app/_components/measure-canvas.tsx
@@ -93,10 +93,7 @@ export default function MeasureCanvas({
 
     function distance(p1: Point, p2: Point) {
       const line = transformPoints([p1, p2], perspective);
-      let d = Math.sqrt(sqrdist(line[0], line[1])) / CSS_PIXELS_PER_INCH;
-      if (unitOfMeasure == CM) {
-        d *= 2.54;
-      }
+      let d = Math.sqrt(sqrdist(line[0], line[1]));
       return `${d.toFixed(2)} ${unitOfMeasure.toLocaleLowerCase()}`;
     }
   }, [

--- a/app/_components/transform-matrix-display.tsx
+++ b/app/_components/transform-matrix-display.tsx
@@ -38,7 +38,11 @@ function formatValue(
     const decimalPart = posValue - integerPart;
     const denominator = getSmallestDenom(posValue, fractionGranularity);
     /* No fraction could be made */
-    if (decimalPart < 0.001 || denominator === null) {
+    if (denominator === null) {
+      return `${sign}${posValue.toFixed(2)}`;
+    }
+    /* Decimal is small enough to just use whole number */
+    if (decimalPart < 0.001) {
       return `${sign}${posValue.toFixed(0)}`;
     }
 

--- a/app/_components/transform-matrix-display.tsx
+++ b/app/_components/transform-matrix-display.tsx
@@ -6,6 +6,7 @@ import { Matrix } from "ml-matrix";
 function getSmallestDenom(
   value: number,
   fractionGranularity: number,
+  epsilon: number = 0.000001,
 ): number | null {
   if (fractionGranularity < 2) return null;
   const integerPart = Math.floor(value);
@@ -16,7 +17,7 @@ function getSmallestDenom(
     if (
       Math.abs(
         Math.round(decimalPart * denominator) / denominator - decimalPart,
-      ) > 0.001
+      ) > epsilon
     ) {
       return smallestFound;
     }
@@ -30,6 +31,7 @@ function formatValue(
   value: number,
   unitOfMeasure: string,
   fractionGranularity: number,
+  epsilon: number = 0.000001,
 ) {
   const sign = value >= 0 ? " " : "-";
   const posValue = Math.abs(value);
@@ -42,7 +44,7 @@ function formatValue(
       return `${sign}${posValue.toFixed(2)}`;
     }
     /* Decimal is small enough to just use whole number */
-    if (decimalPart < 0.001) {
+    if (decimalPart < epsilon) {
       return `${sign}${posValue.toFixed(0)}`;
     }
 

--- a/app/_components/transform-matrix-display.tsx
+++ b/app/_components/transform-matrix-display.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState, useRef } from "react";
+import { decomposeTransformMatrix } from "@/_lib/geometry";
+import { IN, CM } from "@/_lib/unit";
+import { Matrix } from "ml-matrix";
+
+function getSmallestDenom(
+  value: number,
+  fractionGranularity: number,
+): number | null {
+  if (fractionGranularity < 2) return null;
+  const integerPart = Math.floor(value);
+  const decimalPart = value - integerPart;
+  let denominator = fractionGranularity;
+  let smallestFound = null;
+  while (denominator > 1) {
+    if (
+      Math.abs(
+        Math.round(decimalPart * denominator) / denominator - decimalPart,
+      ) > 0.001
+    ) {
+      return smallestFound;
+    }
+    smallestFound = denominator;
+    denominator /= 2;
+  }
+  return smallestFound;
+}
+
+function formatValue(
+  value: number,
+  unitOfMeasure: string,
+  fractionGranularity: number,
+) {
+  const sign = value >= 0 ? " " : "-";
+  const posValue = Math.abs(value);
+  if (unitOfMeasure === IN) {
+    const integerPart = Math.floor(posValue);
+    const decimalPart = posValue - integerPart;
+    const denominator = getSmallestDenom(posValue, fractionGranularity);
+    /* No fraction could be made */
+    if (decimalPart < 0.001 || denominator === null) {
+      return `${sign}${posValue.toFixed(0)}`;
+    }
+
+    const numerator = Math.round(decimalPart * denominator);
+
+    if (denominator !== null) {
+      return integerPart === 0
+        ? `${sign}${numerator}/${denominator}`
+        : `${sign}${integerPart} ${numerator}/${denominator}`;
+    }
+
+    return `${sign}${posValue.toFixed(2)}`;
+  }
+
+  return `${sign}${posValue.toFixed(2)}`;
+}
+
+/* fractionGranularity MUST be a power of two greater than or equal to 2 */
+export default function TransformMatrixDisplay({
+  matrix,
+  unitOfMeasure,
+  fractionGranularity = 16,
+  timeout = 1000,
+  className,
+}: {
+  matrix: Matrix;
+  unitOfMeasure: string;
+  className?: string | undefined;
+  fractionGranularity?: number;
+  timeout?: number;
+}) {
+  const [isVisible, setIsVisible] = useState<boolean>(true);
+  const previousMatrix = useRef<Matrix>(matrix);
+  const initialMatrix = useRef<Matrix | null>(null);
+
+  useEffect(() => {
+    setIsVisible(true);
+    if (initialMatrix.current === null)
+      initialMatrix.current = previousMatrix.current;
+
+    const timer = setTimeout(() => {
+      initialMatrix.current = null;
+      setIsVisible(false);
+    }, timeout);
+
+    previousMatrix.current = matrix;
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [matrix]);
+
+  const decomposed = decomposeTransformMatrix(matrix);
+  const position = decomposed.translation;
+
+  let delta = { x: 0, y: 0 };
+  if (initialMatrix.current !== null) {
+    const deltaMatrix = Matrix.sub(matrix, initialMatrix.current);
+    const decomposedDelta = decomposeTransformMatrix(deltaMatrix);
+    delta = decomposedDelta.translation;
+  }
+
+  return (
+    <div
+      className={`absolute bg-white dark:bg-black text-current w-56 top-20
+      right-4 rounded-lg shadow pr-2 pl-2 pt-1 pb-1 transition-opacity duration-500
+      ease-out select-none
+      ${isVisible ? "opacity-100" : "opacity-0"}
+      ${className}
+      `}
+    >
+      <pre className="text-sm grid grid-cols-8 gap-1">
+        <span>x:</span>
+        <span className="col-span-3">
+          {formatValue(position.x, unitOfMeasure, fractionGranularity)}
+        </span>
+        <span>y:</span>
+        <span className="col-span-3">
+          {formatValue(position.y, unitOfMeasure, fractionGranularity)}
+        </span>
+        <span>Δx:</span>
+        <span className="col-span-3">
+          {formatValue(delta.x, unitOfMeasure, fractionGranularity)}
+        </span>
+        <span>Δy:</span>
+        <span className="col-span-3">
+          {formatValue(delta.y, unitOfMeasure, fractionGranularity)}
+        </span>
+      </pre>
+    </div>
+  );
+}

--- a/app/_components/transform-matrix-display.tsx
+++ b/app/_components/transform-matrix-display.tsx
@@ -103,9 +103,9 @@ export default function TransformMatrixDisplay({
   return (
     <div
       className={`absolute bg-white dark:bg-black text-current w-56 top-20
-      right-4 rounded-lg shadow pr-2 pl-2 pt-1 pb-1 transition-opacity duration-500
+      right-4 rounded-lg shadow pr-2 pl-2 pt-1 pb-1 transition-opacity
       ease-out select-none
-      ${isVisible ? "opacity-100" : "opacity-0"}
+      ${isVisible ? "opacity-100 duration-0" : "opacity-0 duration-500"}
       ${className}
       `}
     >

--- a/app/_hooks/use-key-down.ts
+++ b/app/_hooks/use-key-down.ts
@@ -1,15 +1,27 @@
 import { useCallback, useEffect } from 'react';
 import { KeyCode } from '@/_lib/key-code';
 
-export const useKeyDown = (callback: (T?: any) => void, keyCodes: KeyCode[]) => {
-  const onKeyDown = useCallback((e: KeyboardEvent) => {
-    const keyDown = keyCodes.some((keyCode) => e.code === keyCode);
+export const useKeyDown = (
+  callback: ((keyCode: KeyCode) => void) | (() => void),
+  keyCodes: KeyCode[]
+) => {
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const keyDown = keyCodes.some((keyCode) => e.code === keyCode);
 
-    if (keyDown) {
-      e.preventDefault();
-      callback();
-    }
-  }, [keyCodes, callback]);
+      if (keyDown) {
+        e.preventDefault();
+        const pressedKeyCode = e.code as KeyCode;
+
+        if (callback.length === 1) {
+          (callback as (keyCode: KeyCode) => void)(pressedKeyCode);
+        } else {
+          (callback as () => void)();
+        }
+      }
+    },
+    [keyCodes, callback]
+  );
 
   useEffect(() => {
     document.addEventListener('keydown', onKeyDown);

--- a/app/_hooks/use-key-held.ts
+++ b/app/_hooks/use-key-held.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useCallback } from "react";
+import { KeyCode } from "@/_lib/key-code";
+import { useKeyDown } from "./use-key-down";
+import { useKeyUp } from "./use-key-up";
+
+export const useKeyHeld = (
+  areKeysHeldRef: React.MutableRefObject<boolean>,
+  keyCodes: KeyCode[],
+) => {
+  const heldKeys = useRef<Set<KeyCode>>(new Set());
+
+  useKeyDown((keyCode) => {
+      heldKeys.current.add(keyCode);
+      update();
+  }, keyCodes);
+
+  useKeyUp((keyCode) => {
+    heldKeys.current.delete(keyCode)
+    update();
+  }, keyCodes);
+
+  const update = useCallback(() => {
+    areKeysHeldRef.current = keyCodes.every((keyCode) => heldKeys.current.has(keyCode));
+  },[ keyCodes, areKeysHeldRef ])
+
+};

--- a/app/_hooks/use-key-held.ts
+++ b/app/_hooks/use-key-held.ts
@@ -1,26 +1,31 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, Dispatch } from "react";
 import { KeyCode } from "@/_lib/key-code";
 import { useKeyDown } from "./use-key-down";
 import { useKeyUp } from "./use-key-up";
 
 export const useKeyHeld = (
-  areKeysHeldRef: React.MutableRefObject<boolean>,
+  areKeysHeldRefOrDispatch: React.MutableRefObject<boolean> | Dispatch<boolean>,
   keyCodes: KeyCode[],
 ) => {
   const heldKeys = useRef<Set<KeyCode>>(new Set());
 
   useKeyDown((keyCode) => {
-      heldKeys.current.add(keyCode);
-      update();
+    heldKeys.current.add(keyCode);
+    update();
   }, keyCodes);
 
   useKeyUp((keyCode) => {
-    heldKeys.current.delete(keyCode)
+    heldKeys.current.delete(keyCode);
     update();
   }, keyCodes);
 
   const update = useCallback(() => {
-    areKeysHeldRef.current = keyCodes.every((keyCode) => heldKeys.current.has(keyCode));
-  },[ keyCodes, areKeysHeldRef ])
+    const areKeysHeld = keyCodes.every((keyCode) => heldKeys.current.has(keyCode));
 
+    if (areKeysHeldRefOrDispatch instanceof Function) {
+      areKeysHeldRefOrDispatch(areKeysHeld);
+    } else {
+      areKeysHeldRefOrDispatch.current = areKeysHeld;
+    }
+  }, [keyCodes, areKeysHeldRefOrDispatch]);
 };

--- a/app/_hooks/use-key-toggle.ts
+++ b/app/_hooks/use-key-toggle.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useCallback, Dispatch } from "react";
+import { KeyCode } from "@/_lib/key-code";
+import { useKeyDown } from "./use-key-down";
+
+export const useKeyToggle = (
+  anyKeyRefOrDispatch: React.MutableRefObject<boolean> | Dispatch<boolean>,
+  keyCodes: KeyCode[],
+) => {
+  const toggledKeys = useRef<Set<KeyCode>>(new Set());
+
+  useKeyDown((keyCode) => {
+    if (toggledKeys.current.has(keyCode))
+      toggledKeys.current.delete(keyCode);
+    else
+      toggledKeys.current.add(keyCode);
+    update();
+  }, keyCodes);
+
+  const update = useCallback(() => {
+    const anyKeyToggled = keyCodes.some((keyCode) => toggledKeys.current.has(keyCode));
+
+    if (anyKeyRefOrDispatch instanceof Function) {
+      anyKeyRefOrDispatch(anyKeyToggled);
+    } else {
+      anyKeyRefOrDispatch.current = anyKeyToggled;
+    }
+  }, [keyCodes, anyKeyRefOrDispatch]);
+};

--- a/app/_hooks/use-key-up.ts
+++ b/app/_hooks/use-key-up.ts
@@ -1,24 +1,33 @@
-import { useCallback, useEffect } from "react";
-import { KeyCode } from "@/_lib/key-code";
+import { useCallback, useEffect } from 'react';
+import { KeyCode } from '@/_lib/key-code';
 
-export const useKeyUp = (callback: (T?: any) => void, keyCodes: KeyCode[]) => {
+export const useKeyUp = (
+  callback: ((keyCode: KeyCode) => void) | (() => void),
+  keyCodes: KeyCode[]
+) => {
   const onKeyUp = useCallback(
     (e: KeyboardEvent) => {
       const keyUp = keyCodes.some((keyCode) => e.code === keyCode);
 
       if (keyUp) {
         e.preventDefault();
-        callback();
+        const releasedKeyCode = e.code as KeyCode;
+
+        if (callback.length === 1) {
+          (callback as (keyCode: KeyCode) => void)(releasedKeyCode);
+        } else {
+          (callback as () => void)();
+        }
       }
     },
-    [keyCodes, callback],
+    [keyCodes, callback]
   );
 
   useEffect(() => {
-    document.addEventListener("keyup", onKeyUp);
+    document.addEventListener('keyup', onKeyUp);
 
     return () => {
-      document.removeEventListener("keyup", onKeyUp);
+      document.removeEventListener('keyup', onKeyUp);
     };
   }, [onKeyUp]);
 };

--- a/app/_hooks/use-key-up.ts
+++ b/app/_hooks/use-key-up.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect } from "react";
+import { KeyCode } from "@/_lib/key-code";
+
+export const useKeyUp = (callback: (T?: any) => void, keyCodes: KeyCode[]) => {
+  const onKeyUp = useCallback(
+    (e: KeyboardEvent) => {
+      const keyUp = keyCodes.some((keyCode) => e.code === keyCode);
+
+      if (keyUp) {
+        e.preventDefault();
+        callback();
+      }
+    },
+    [keyCodes, callback],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.removeEventListener("keyup", onKeyUp);
+    };
+  }, [onKeyUp]);
+};

--- a/app/_hooks/useProgArrowKeyHandler.ts
+++ b/app/_hooks/useProgArrowKeyHandler.ts
@@ -5,12 +5,18 @@ export default function useProgArrowKeyHandler(
   handler: (key: string, px: number) => void,
   active: boolean,
   pixelList: number[] = PIXEL_LIST,
+  modifierScale?: number
 ) {
   const [pixelIdx, setPixelIdx] = useState<number>(0);
   const [timeoutFunc, setTimeoutFunc] = useState<NodeJS.Timeout | null>();
+  const [shiftPressed, setShiftPressed] = useState<boolean>(false);
+  const scale = modifierScale !== undefined ? modifierScale : 16;
 
   const keydownHandler = useCallback(
     function (e: KeyboardEvent) {
+      if (e.shiftKey) {
+        setShiftPressed(true);
+      }
       if (
         ["ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown"].includes(e.code)
       ) {
@@ -23,14 +29,18 @@ export default function useProgArrowKeyHandler(
             }, 600),
           );
         }
-        handler(e.code, pixelList[pixelIdx]);
+        const pixelValue = shiftPressed ? pixelList[pixelIdx] * scale : pixelList[pixelIdx];
+        handler(e.code, pixelValue);
       }
     },
-    [timeoutFunc, pixelIdx, handler, pixelList],
+    [timeoutFunc, pixelIdx, handler, pixelList, shiftPressed],
   );
 
   const keyupHandler = useCallback(
-    function () {
+    function (e: KeyboardEvent) {
+      if (e.code === "ShiftLeft" || e.code === "ShiftRight") {
+        setShiftPressed(false);
+      }
       if (timeoutFunc) {
         clearTimeout(timeoutFunc);
         setTimeoutFunc(null);

--- a/app/_hooks/useProgArrowKeyHandler.ts
+++ b/app/_hooks/useProgArrowKeyHandler.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { useKeyDown } from "@/_hooks/use-key-down";
 import { useKeyUp } from "@/_hooks/use-key-up";
 import { KeyCode } from "@/_lib/key-code";
@@ -12,10 +12,12 @@ export default function useProgArrowKeyHandler(
 ) {
   const [pixelIdx, setPixelIdx] = useState<number>(0);
   const [timeoutFunc, setTimeoutFunc] = useState<NodeJS.Timeout | null>();
-  const [shiftPressed, setShiftPressed] = useState<boolean>(false);
+  const shiftPressedRef= useRef<boolean>(false);
 
   const arrowKeyHandler = useCallback(
     function (keycode: KeyCode) {
+      if (!active)
+        return;
       if (!timeoutFunc && pixelIdx < pixelList.length - 1) {
         setTimeoutFunc(
           setTimeout(() => {
@@ -24,12 +26,12 @@ export default function useProgArrowKeyHandler(
           }, 600),
         );
       }
-      const pixelValue = shiftPressed
+      const pixelValue = shiftPressedRef.current
         ? pixelList[pixelIdx] * modifierScale
         : pixelList[pixelIdx];
       handler(keycode, pixelValue);
     },
-    [timeoutFunc, pixelIdx, handler, pixelList, shiftPressed],
+    [timeoutFunc, pixelIdx, handler, pixelList],
   );
 
   const keyupHandler = useCallback(
@@ -44,11 +46,11 @@ export default function useProgArrowKeyHandler(
   );
 
   useKeyDown(() => {
-    setShiftPressed(true);
+    shiftPressedRef.current = true;
   }, [KeyCode.ShiftLeft]);
 
   useKeyUp(() => {
-    setShiftPressed(false);
+    shiftPressedRef.current = false;
   }, [KeyCode.ShiftLeft]);
 
   useKeyDown(

--- a/app/_hooks/useProgArrowKeyHandler.ts
+++ b/app/_hooks/useProgArrowKeyHandler.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import { useKeyDown } from "@/_hooks/use-key-down";
 import { useKeyUp } from "@/_hooks/use-key-up";
+import { useKeyHeld } from "@/_hooks/use-key-held";
 import { KeyCode } from "@/_lib/key-code";
 
 const PIXEL_LIST = [2, 20, 50, 100];
@@ -12,7 +13,7 @@ export default function useProgArrowKeyHandler(
 ) {
   const [pixelIdx, setPixelIdx] = useState<number>(0);
   const [timeoutFunc, setTimeoutFunc] = useState<NodeJS.Timeout | null>();
-  const shiftPressedRef= useRef<boolean>(false);
+  const shiftHeldRef = useRef<boolean>(false);
 
   const arrowKeyHandler = useCallback(
     function (keycode: KeyCode) {
@@ -26,12 +27,12 @@ export default function useProgArrowKeyHandler(
           }, 600),
         );
       }
-      const pixelValue = shiftPressedRef.current
+      const pixelValue = shiftHeldRef.current
         ? pixelList[pixelIdx] * modifierScale
         : pixelList[pixelIdx];
       handler(keycode, pixelValue);
     },
-    [timeoutFunc, pixelIdx, handler, pixelList],
+    [timeoutFunc, pixelIdx, handler, pixelList, shiftHeldRef],
   );
 
   const keyupHandler = useCallback(
@@ -45,13 +46,7 @@ export default function useProgArrowKeyHandler(
     [timeoutFunc],
   );
 
-  useKeyDown(() => {
-    shiftPressedRef.current = true;
-  }, [KeyCode.ShiftLeft]);
-
-  useKeyUp(() => {
-    shiftPressedRef.current = false;
-  }, [KeyCode.ShiftLeft]);
+  useKeyHeld(shiftHeldRef, [KeyCode.ShiftLeft]);
 
   useKeyDown(
     (key: KeyCode) => {

--- a/app/_hooks/useProgArrowKeyHandler.ts
+++ b/app/_hooks/useProgArrowKeyHandler.ts
@@ -1,46 +1,39 @@
 import { useCallback, useEffect, useState } from "react";
+import { useKeyDown } from "@/_hooks/use-key-down";
+import { useKeyUp } from "@/_hooks/use-key-up";
+import { KeyCode } from "@/_lib/key-code";
 
 const PIXEL_LIST = [2, 20, 50, 100];
 export default function useProgArrowKeyHandler(
-  handler: (key: string, px: number) => void,
+  handler: (key: KeyCode, px: number) => void,
   active: boolean,
   pixelList: number[] = PIXEL_LIST,
-  modifierScale?: number
+  modifierScale: number = 16,
 ) {
   const [pixelIdx, setPixelIdx] = useState<number>(0);
   const [timeoutFunc, setTimeoutFunc] = useState<NodeJS.Timeout | null>();
   const [shiftPressed, setShiftPressed] = useState<boolean>(false);
-  const scale = modifierScale !== undefined ? modifierScale : 16;
 
-  const keydownHandler = useCallback(
-    function (e: KeyboardEvent) {
-      if (e.shiftKey) {
-        setShiftPressed(true);
+  const arrowKeyHandler = useCallback(
+    function (keycode: KeyCode) {
+      if (!timeoutFunc && pixelIdx < pixelList.length - 1) {
+        setTimeoutFunc(
+          setTimeout(() => {
+            setPixelIdx(pixelIdx + 1);
+            setTimeoutFunc(null);
+          }, 600),
+        );
       }
-      if (
-        ["ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown"].includes(e.code)
-      ) {
-        e.preventDefault();
-        if (!timeoutFunc && pixelIdx < pixelList.length - 1) {
-          setTimeoutFunc(
-            setTimeout(() => {
-              setPixelIdx(pixelIdx + 1);
-              setTimeoutFunc(null);
-            }, 600),
-          );
-        }
-        const pixelValue = shiftPressed ? pixelList[pixelIdx] * scale : pixelList[pixelIdx];
-        handler(e.code, pixelValue);
-      }
+      const pixelValue = shiftPressed
+        ? pixelList[pixelIdx] * modifierScale
+        : pixelList[pixelIdx];
+      handler(keycode, pixelValue);
     },
     [timeoutFunc, pixelIdx, handler, pixelList, shiftPressed],
   );
 
   const keyupHandler = useCallback(
-    function (e: KeyboardEvent) {
-      if (e.code === "ShiftLeft" || e.code === "ShiftRight") {
-        setShiftPressed(false);
-      }
+    function () {
       if (timeoutFunc) {
         clearTimeout(timeoutFunc);
         setTimeoutFunc(null);
@@ -50,14 +43,36 @@ export default function useProgArrowKeyHandler(
     [timeoutFunc],
   );
 
-  useEffect(() => {
-    if (active) {
-      document.addEventListener("keydown", keydownHandler);
-      document.addEventListener("keyup", keyupHandler);
-      return () => {
-        document.removeEventListener("keydown", keydownHandler);
-        document.addEventListener("keyup", keyupHandler);
-      };
-    }
-  }, [keydownHandler, keyupHandler, active]);
+  useKeyDown(() => {
+    setShiftPressed(true);
+  }, [KeyCode.ShiftLeft]);
+
+  useKeyDown(() => {
+    arrowKeyHandler(KeyCode.ArrowUp);
+  }, [KeyCode.ArrowUp]);
+
+  useKeyDown(() => {
+    arrowKeyHandler(KeyCode.ArrowDown);
+  }, [KeyCode.ArrowDown]);
+
+  useKeyDown(() => {
+    arrowKeyHandler(KeyCode.ArrowLeft);
+  }, [KeyCode.ArrowLeft]);
+
+  useKeyDown(() => {
+    arrowKeyHandler(KeyCode.ArrowRight);
+  }, [KeyCode.ArrowRight]);
+
+  useKeyUp(() => {
+    setShiftPressed(false);
+  }, [KeyCode.ShiftLeft]);
+
+  useKeyUp(() => {
+    keyupHandler();
+  }, [
+    KeyCode.ArrowUp,
+    KeyCode.ArrowDown,
+    KeyCode.ArrowLeft,
+    KeyCode.ArrowRight,
+  ]);
 }

--- a/app/_hooks/useProgArrowKeyHandler.ts
+++ b/app/_hooks/useProgArrowKeyHandler.ts
@@ -47,25 +47,16 @@ export default function useProgArrowKeyHandler(
     setShiftPressed(true);
   }, [KeyCode.ShiftLeft]);
 
-  useKeyDown(() => {
-    arrowKeyHandler(KeyCode.ArrowUp);
-  }, [KeyCode.ArrowUp]);
-
-  useKeyDown(() => {
-    arrowKeyHandler(KeyCode.ArrowDown);
-  }, [KeyCode.ArrowDown]);
-
-  useKeyDown(() => {
-    arrowKeyHandler(KeyCode.ArrowLeft);
-  }, [KeyCode.ArrowLeft]);
-
-  useKeyDown(() => {
-    arrowKeyHandler(KeyCode.ArrowRight);
-  }, [KeyCode.ArrowRight]);
-
   useKeyUp(() => {
     setShiftPressed(false);
   }, [KeyCode.ShiftLeft]);
+
+  useKeyDown(
+    (key: KeyCode) => {
+      arrowKeyHandler(key);
+    },
+    [KeyCode.ArrowUp, KeyCode.ArrowDown, KeyCode.ArrowLeft, KeyCode.ArrowRight],
+  );
 
   useKeyUp(() => {
     keyupHandler();

--- a/app/_hooks/useProgArrowKeyPoints.ts
+++ b/app/_hooks/useProgArrowKeyPoints.ts
@@ -3,6 +3,7 @@ import { applyOffset, Point } from "@/_lib/point";
 import { translate } from "@/_lib/geometry";
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
 import { Matrix } from "ml-matrix";
+import { KeyCode } from "@/_lib/key-code";
 
 export default function useProgArrowKeyPoints(
   points: Point[],
@@ -10,21 +11,21 @@ export default function useProgArrowKeyPoints(
   pointToModify: number | null,
   active: boolean,
 ) {
-  function getNewOffset(key: string, px: number) {
+  function getNewOffset(key: KeyCode, px: number) {
     if (pointToModify !== null) {
       const newPoints = [...points];
       let newPoint: Point = points[pointToModify];
       switch (key) {
-        case "ArrowUp":
+        case KeyCode.ArrowUp:
           newPoint = applyOffset(points[pointToModify], { y: -px, x: 0 });
           break;
-        case "ArrowDown":
+        case KeyCode.ArrowDown:
           newPoint = applyOffset(points[pointToModify], { y: px, x: 0 });
           break;
-        case "ArrowLeft":
+        case KeyCode.ArrowLeft:
           newPoint = applyOffset(points[pointToModify], { y: 0, x: -px });
           break;
-        case "ArrowRight":
+        case KeyCode.ArrowRight:
           newPoint = applyOffset(points[pointToModify], { y: 0, x: px });
           break;
         default:

--- a/app/_hooks/useProgArrowKeyToMatrix.ts
+++ b/app/_hooks/useProgArrowKeyToMatrix.ts
@@ -10,9 +10,10 @@ export default function useProgArrowKeyToMatrix(
   applyChange: (matrix: Matrix) => void,
   ) {
   const PIXEL_LIST = [1, 10, 20, 100];
+  const inverseScale = 1.0 / scale;
   function moveWithArrowKey(key: string, px: number) {
     let newOffset: Point = { x: 0, y: 0 };
-    const dist = px*scale;
+    const dist = px*inverseScale;
     switch (key) {
       case "ArrowUp":
         newOffset = { y: -dist, x: 0 };
@@ -33,5 +34,5 @@ export default function useProgArrowKeyToMatrix(
     applyChange(m);
   }
 
-  useProgArrowKeyHandler(moveWithArrowKey, active, PIXEL_LIST);
+  useProgArrowKeyHandler(moveWithArrowKey, active, PIXEL_LIST, scale);
 }

--- a/app/_hooks/useProgArrowKeyToMatrix.ts
+++ b/app/_hooks/useProgArrowKeyToMatrix.ts
@@ -3,28 +3,29 @@ import { applyOffset, Point } from "@/_lib/point";
 import { translate } from "@/_lib/geometry";
 import { useEffect, useMemo, useState } from "react";
 import { Matrix } from "ml-matrix";
+import { KeyCode } from "@/_lib/key-code";
 
 export default function useProgArrowKeyToMatrix(
   active: boolean,
   scale: number,
   applyChange: (matrix: Matrix) => void,
-  ) {
+) {
   const PIXEL_LIST = [1, 10, 20, 100];
   const inverseScale = 1.0 / scale;
-  function moveWithArrowKey(key: string, px: number) {
+  function moveWithArrowKey(key: KeyCode, px: number) {
     let newOffset: Point = { x: 0, y: 0 };
-    const dist = px*inverseScale;
+    const dist = px * inverseScale;
     switch (key) {
-      case "ArrowUp":
+      case KeyCode.ArrowUp:
         newOffset = { y: -dist, x: 0 };
         break;
-      case "ArrowDown":
+      case KeyCode.ArrowDown:
         newOffset = { y: dist, x: 0 };
         break;
-      case "ArrowLeft":
+      case KeyCode.ArrowLeft:
         newOffset = { y: 0, x: -dist };
         break;
-      case "ArrowRight":
+      case KeyCode.ArrowRight:
         newOffset = { y: 0, x: dist };
         break;
       default:

--- a/app/_lib/key-code.ts
+++ b/app/_lib/key-code.ts
@@ -1,5 +1,6 @@
 export enum KeyCode {
  KeyM = 'KeyM',
+ KeyG = 'KeyG',
  Escape = 'Escape',
  ShiftLeft = 'ShiftLeft',
  ShiftRight = 'ShiftRight',

--- a/app/_lib/key-code.ts
+++ b/app/_lib/key-code.ts
@@ -1,4 +1,10 @@
 export enum KeyCode {
  KeyM = 'KeyM',
  Escape = 'Escape',
+ ShiftLeft = 'ShiftLeft',
+ ShiftRight = 'ShiftRight',
+ ArrowUp = 'ArrowUp',
+ ArrowDown = 'ArrowDown',
+ ArrowLeft = 'ArrowLeft',
+ ArrowRight = 'ArrowRight',
 }

--- a/app/_lib/key-code.ts
+++ b/app/_lib/key-code.ts
@@ -1,6 +1,7 @@
 export enum KeyCode {
  KeyM = 'KeyM',
  KeyG = 'KeyG',
+ KeyL = 'KeyL',
  Escape = 'Escape',
  ShiftLeft = 'ShiftLeft',
  ShiftRight = 'ShiftRight',


### PR DESCRIPTION
Holding shift while pressing arrow keys multiplies the movement by 16 (default).

For moving the PDF, the holding shift makes the arrow keys move the PDF by 1 inch/cm. Without the shift key it's moved by 1/scale (scale = 16, so 1/16th inch/cm).