### PR TITLE
Changed perspective matrix to be in units of measure. 

### DIFF
--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -159,6 +159,12 @@ export default function Page() {
     requestWakeLock();
   });
 
+  /* Reset the PDF position on unit change.
+   * Prevents PDF from going off-screen after cm->in */
+  useEffect(() => {
+    setLocalTransform(Matrix.identity(3));
+  }, [unitOfMeasure])
+
   useEffect(() => {
     const ptDensity = getPtDensity(unitOfMeasure);
     setLayoutWidth(layoutWidthPt / ptDensity);

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -112,7 +112,7 @@ export default function Header({
       { x: layoutWidth * 0.5, y: layoutHeight * 0.5 },
       localTransform,
     );
-    const center = getCenterPoint(+width, +height, unitOfMeasure);
+    const center = getCenterPoint(+width, +height);
     const p = {
       x: center.x - current.x,
       y: center.y - current.y,
@@ -339,7 +339,7 @@ export default function Header({
                 onClick={() =>
                   setLocalTransform(
                     flipHorizontal(
-                      getCenterPoint(+width, +height, unitOfMeasure),
+                      getCenterPoint(+width, +height),
                     ).mmul(localTransform),
                   )
                 }
@@ -352,7 +352,7 @@ export default function Header({
                 onClick={() =>
                   setLocalTransform(
                     flipVertical(
-                      getCenterPoint(+width, +height, unitOfMeasure),
+                      getCenterPoint(+width, +height),
                     ).mmul(localTransform),
                   )
                 }
@@ -366,7 +366,7 @@ export default function Header({
                   setLocalTransform(
                     rotateMatrixDeg(
                       90,
-                      getCenterPoint(+width, +height, unitOfMeasure),
+                      getCenterPoint(+width, +height),
                     ).mmul(localTransform),
                   )
                 }

--- a/app/_components/measure-canvas.tsx
+++ b/app/_components/measure-canvas.tsx
@@ -95,10 +95,7 @@ export default function MeasureCanvas({
 
     function distance(p1: Point, p2: Point) {
       const line = transformPoints([p1, p2], perspective);
-      let d = Math.sqrt(sqrdist(line[0], line[1])) / CSS_PIXELS_PER_INCH;
-      if (unitOfMeasure == CM) {
-        d *= 2.54;
-      }
+      let d = Math.sqrt(sqrdist(line[0], line[1]))
       return `${d.toFixed(2)} ${unitOfMeasure.toLocaleLowerCase()}`;
     }
   }, [

--- a/app/_components/pdf-viewer.tsx
+++ b/app/_components/pdf-viewer.tsx
@@ -32,8 +32,8 @@ export default function PdfViewer({
   file,
   setLayers,
   setPageCount,
-  setLayoutWidth,
-  setLayoutHeight,
+  setLayoutWidthPt,
+  setLayoutHeightPt,
   setLocalTransform,
   pageCount,
   layers,
@@ -45,8 +45,8 @@ export default function PdfViewer({
   file: any;
   setLayers: Dispatch<SetStateAction<Map<string, Layer>>>;
   setPageCount: Dispatch<SetStateAction<number>>;
-  setLayoutWidth: Dispatch<SetStateAction<number>>;
-  setLayoutHeight: Dispatch<SetStateAction<number>>;
+  setLayoutWidthPt: Dispatch<SetStateAction<number>>;
+  setLayoutHeightPt: Dispatch<SetStateAction<number>>;
   setLocalTransform: Dispatch<SetStateAction<Matrix>>;
   pageCount: number;
   layers: Map<string, Layer>;
@@ -89,16 +89,16 @@ export default function PdfViewer({
       pageWidth * columns - (columns - 1) * Number(edgeInsets.horizontal);
     const h =
       pageHeight * rowCount - (rowCount - 1) * Number(edgeInsets.vertical);
-    setLayoutWidth(w);
-    setLayoutHeight(h);
+    setLayoutWidthPt(w);
+    setLayoutHeightPt(h);
   }, [
     pageWidth,
     pageHeight,
     pageRange,
     columnCount,
     pageCount,
-    setLayoutWidth,
-    setLayoutHeight,
+    setLayoutWidthPt,
+    setLayoutHeightPt,
     edgeInsets,
   ]);
 

--- a/app/_lib/geometry.ts
+++ b/app/_lib/geometry.ts
@@ -145,10 +145,10 @@ function getDstVertices(width: number, height: number, ptDensity: number): Point
   return rectCorners(dx, dy);
 }
 
-export function getCenterPoint(width: number, height: number, unitOfMeasure: string): Point {
+export function getCenterPoint(width: number, height: number): Point {
   return {
-    x: width * getPtDensity(unitOfMeasure) * 0.5,
-    y: height * getPtDensity(unitOfMeasure) * 0.5,
+    x: width * 0.5,
+    y: height * 0.5,
   }
 }
 
@@ -220,6 +220,13 @@ export function flipVertical(origin: Point): Matrix {
 
 export function flipHorizontal(origin: Point): Matrix {
   return transformAboutPoint(scale(-1, 1), origin);
+}
+
+export function scaleTranslation(matrix: Matrix, scale: number): Point {
+  let newMatrix = matrix.clone()
+  newMatrix.set(0,2, matrix.get(0,2) * scale);
+  newMatrix.set(1,2, matrix.get(1,2) * scale);
+  return newMatrix;
 }
 
 /**

--- a/app/_lib/geometry.ts
+++ b/app/_lib/geometry.ts
@@ -222,7 +222,7 @@ export function flipHorizontal(origin: Point): Matrix {
   return transformAboutPoint(scale(-1, 1), origin);
 }
 
-export function scaleTranslation(matrix: Matrix, scale: number): Point {
+export function scaleTranslation(matrix: Matrix, scale: number): Matrix {
   let newMatrix = matrix.clone()
   newMatrix.set(0,2, matrix.get(0,2) * scale);
   newMatrix.set(1,2, matrix.get(1,2) * scale);


### PR DESCRIPTION
In my opinion, the perspective matrix (and therefore localTransform) should be in units of measure rather than PDF pt units. This simplifies a lot of operations as you don't have to take into account the ptDensity.

I also changed what was formerly layoutWidth/layoutHeight to layoutWidthPt/layoutHeightPt. This is the layout size in PDF units. Now, layoutWidth/layoutHeight is in units of measure, which also simplifies some operations (such as the recenter button).