### PR TITLE
Add scale tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Scale tool
 - Full screen button to projection page
 - Cursor changes from grab to grabbing hand when dragging
 - Selected corner on calibration grid is colored

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -88,7 +88,7 @@ export default function Page() {
     horizontal: "0",
     vertical: "0",
   });
-
+  const [patternScale, setPatternScale] = useState<number>(1);
   const [menuStates, setMenuStates] = useState<MenuStates>(
     getDefaultMenuStates(),
   );
@@ -127,6 +127,10 @@ export default function Page() {
   }
 
   // HANDLERS
+
+  function handleScaleChange(e: ChangeEvent<HTMLInputElement>) {
+    setPatternScale(Number(e.target.value) / 100);
+  }
 
   function handleHeightChange(e: ChangeEvent<HTMLInputElement>) {
     const h = removeNonDigits(e.target.value, height);
@@ -365,6 +369,8 @@ export default function Page() {
                 updateLocalSettings({ showingMovePad: show });
               }}
               setCalibrationValidated={setCalibrationValidated}
+              scale={patternScale}
+              handleScaleChange={handleScaleChange}
             />
 
             <StitchMenu
@@ -446,6 +452,7 @@ export default function Page() {
                 setEdgeInsets={setEdgeInsets}
                 pageRange={pageRange}
                 filter={themeFilter(displaySettings.theme)}
+                scale={patternScale}
               />
             </Draggable>
           </Transformable>

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -85,6 +85,8 @@ export default function Header({
   showingMovePad,
   setShowingMovePad,
   setCalibrationValidated,
+  scale,
+  handleScaleChange,
 }: {
   isCalibrating: boolean;
   setIsCalibrating: Dispatch<SetStateAction<boolean>>;
@@ -111,6 +113,8 @@ export default function Header({
   showingMovePad: boolean;
   setShowingMovePad: Dispatch<SetStateAction<boolean>>;
   setCalibrationValidated: Dispatch<SetStateAction<boolean>>;
+  scale: number;
+  handleScaleChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }) {
   const [calibrationAlert, setCalibrationAlert] = useState("");
   const transformer = useTransformerContext();
@@ -398,15 +402,29 @@ export default function Header({
               </IconButton>
             </Tooltip>
 
-            {!isCalibrating && (
-              <DropdownIconButton
-                description={t("lineWeight")}
-                icon={<LineWeightIcon ariaLabel={t("lineWeight")} />}
-                options={lineThicknessOptions}
-                setSelection={setLineThickness}
-                selection={lineThickness}
+            <Tooltip description={t("scale")}>
+              <InlineInput
+                className="relative flex flex-col"
+                inputClassName="w-28"
+                handleChange={handleScaleChange}
+                id="scale"
+                label={t("scale")}
+                name="scale"
+                value={(scale * 100).toFixed(0)}
+                labelRight={"%"}
+                type="number"
+                min="0"
+                step="5"
               />
-            )}
+            </Tooltip>
+
+            <DropdownIconButton
+              description={t("lineWeight")}
+              icon={<LineWeightIcon ariaLabel={t("lineWeight")} />}
+              options={lineThicknessOptions}
+              setSelection={setLineThickness}
+              selection={lineThickness}
+            />
 
             <Tooltip description={t("flipHorizontal")}>
               <IconButton

--- a/app/_components/inline-input.tsx
+++ b/app/_components/inline-input.tsx
@@ -21,6 +21,7 @@ export default function InlineInput({
   value,
   min,
   type,
+  step,
 }: {
   className?: string | undefined;
   inputClassName?: string | undefined;
@@ -33,6 +34,7 @@ export default function InlineInput({
   value: string;
   type?: string;
   min?: string;
+  step?: string;
 }) {
   return (
     <div className={className}>
@@ -52,6 +54,7 @@ export default function InlineInput({
         onChange={(e: ChangeEvent<HTMLInputElement>) => handleChange(e)}
         required
         value={value}
+        step={step}
       />
       <label
         className="text-sm text-gray-500 dark:text-white mb-2 absolute right-2 top-0 h-full flex items-center"

--- a/app/_components/pdf-viewer.tsx
+++ b/app/_components/pdf-viewer.tsx
@@ -38,6 +38,7 @@ export default function PdfViewer({
   setEdgeInsets,
   pageRange,
   filter,
+  scale,
 }: {
   file: any;
   setLayers: Dispatch<SetStateAction<Map<string, Layer>>>;
@@ -52,6 +53,7 @@ export default function PdfViewer({
   setEdgeInsets: Dispatch<SetStateAction<EdgeInsets>>;
   pageRange: string;
   filter: string;
+  scale: number;
 }) {
   const [pageSizes, setPageSize] = useReducer(
     pageSizeReducer,
@@ -82,17 +84,14 @@ export default function PdfViewer({
   }, []);
 
   useEffect(() => {
-    const pages = getPageNumbers(pageRange, pageCount);
-    const itemCount = pages.length;
-    const columns = Math.max(Math.min(Number(columnCount), itemCount), 1);
-    const rowCount = Math.ceil((itemCount || 1) / columns);
-    const [tileWidth, tileHeight] = getTileSize(pages, pageSizes);
-    const w =
-      tileWidth * columns -
-      (columns - 1) * PDF_TO_CSS_UNITS * Number(edgeInsets.horizontal);
-    const h =
-      tileHeight * rowCount -
-      (rowCount - 1) * PDF_TO_CSS_UNITS * Number(edgeInsets.vertical);
+    const [w, h] = getLayoutSize(
+      pageSizes,
+      pageRange,
+      pageCount,
+      columnCount,
+      edgeInsets,
+      scale,
+    );
     setLayoutWidth(w);
     setLayoutHeight(h);
   }, [
@@ -103,17 +102,15 @@ export default function PdfViewer({
     setLayoutWidth,
     setLayoutHeight,
     edgeInsets,
+    scale,
   ]);
 
   const pages = getPageNumbers(pageRange, pageCount);
   const keys = getKeys(pages);
-  const [tileWidth, tileHeight] = getTileSize(pages, pageSizes);
-  const cssEdgeInsets = {
-    vertical: Number(edgeInsets.vertical) * PDF_TO_CSS_UNITS,
-    horizontal: Number(edgeInsets.horizontal) * PDF_TO_CSS_UNITS,
-  };
-  const insetWidth = `${tileWidth - cssEdgeInsets.horizontal}px`;
-  const insetHeight = `${tileHeight - cssEdgeInsets.vertical}px`;
+  const [tileWidth, tileHeight] = getTileSize(pages, pageSizes, scale);
+  const cssEdgeInsets = getCSSEdgeInsets(edgeInsets, scale);
+  const insetWidth = `${tileWidth - Number(cssEdgeInsets.horizontal)}px`;
+  const insetHeight = `${tileHeight - Number(cssEdgeInsets.vertical)}px`;
 
   return (
     <Document file={file} onLoadSuccess={onDocumentLoadSuccess}>
@@ -121,8 +118,8 @@ export default function PdfViewer({
         style={{
           display: "grid",
           gridTemplateColumns: `repeat(${columnCount}, max-content)`,
-          marginRight: cssEdgeInsets.horizontal,
-          marginBottom: cssEdgeInsets.vertical,
+          paddingRight: cssEdgeInsets.horizontal + "px",
+          paddingBottom: cssEdgeInsets.vertical + "px",
           filter: filter,
         }}
       >
@@ -134,17 +131,18 @@ export default function PdfViewer({
                 width: insetWidth,
                 height: insetHeight,
                 mixBlendMode:
-                  cssEdgeInsets.horizontal == 0 && cssEdgeInsets.vertical == 0
+                  Number(cssEdgeInsets.horizontal) == 0 &&
+                  Number(cssEdgeInsets.vertical) == 0
                     ? "normal"
                     : "darken",
               }}
             >
               {value != 0 && (
                 <RenderContext.Provider
-                  value={{ layers, setLayers, erosions: lineThickness }}
+                  value={{ layers, setLayers, erosions: lineThickness, scale }}
                 >
                   <Page
-                    scale={PDF_TO_CSS_UNITS}
+                    scale={PDF_TO_CSS_UNITS * scale}
                     pageNumber={value}
                     renderMode="custom"
                     customRenderer={CustomRenderer}
@@ -192,6 +190,7 @@ function pageSizeReducer(
 function getTileSize(
   pages: number[],
   pageSizes: Map<number, { width: number; height: number }>,
+  scale: number,
 ): [number, number] {
   let tileWidth = 0;
   let tileHeight = 0;
@@ -199,5 +198,38 @@ function getTileSize(
     tileWidth = Math.max(tileWidth, pageSizes.get(page)?.width ?? 0);
     tileHeight = Math.max(tileHeight, pageSizes.get(page)?.height ?? 0);
   }
-  return [tileWidth, tileHeight];
+  return [tileWidth * scale, tileHeight * scale];
+}
+
+function getLayoutSize(
+  pageSizes: Map<number, { width: number; height: number }>,
+  pageRange: string,
+  pageCount: number,
+  columnCount: string,
+  edgeInsets: EdgeInsets,
+  scale: number,
+): [number, number] {
+  const pages = getPageNumbers(pageRange, pageCount);
+  const [columns, rowCount] = getGridSize(pages, columnCount);
+  const [tileWidth, tileHeight] = getTileSize(pages, pageSizes, scale);
+  const insets = getCSSEdgeInsets(edgeInsets, scale);
+  const w = tileWidth * columns - (columns - 1) * Number(insets.horizontal);
+  const h = tileHeight * rowCount - (rowCount - 1) * Number(insets.vertical);
+  return [w, h];
+}
+
+function getGridSize(pages: number[], columnCount: string): [number, number] {
+  const itemCount = pages.length;
+  const columns = Math.max(Math.min(Number(columnCount), itemCount), 1);
+  const rows = Math.ceil((itemCount || 1) / columns);
+  return [columns, rows];
+}
+
+function getCSSEdgeInsets(edgeInsets: EdgeInsets, scale: number): EdgeInsets {
+  return {
+    vertical: String(Number(edgeInsets.vertical) * PDF_TO_CSS_UNITS * scale),
+    horizontal: String(
+      Number(edgeInsets.horizontal) * PDF_TO_CSS_UNITS * scale,
+    ),
+  };
 }

--- a/app/_hooks/use-render-context.ts
+++ b/app/_hooks/use-render-context.ts
@@ -6,12 +6,14 @@ export interface RenderContextType {
   erosions: number;
   layers: Map<string, Layer>;
   setLayers: (layer: Map<string, Layer>) => void;
+  scale: number;
 }
 
 export const RenderContext = createContext<RenderContextType>({
   layers: new Map(),
   setLayers: () => {},
   erosions: 0,
+  scale: 1,
 });
 
 export default function useRenderContext() {

--- a/messages/en.json
+++ b/messages/en.json
@@ -181,7 +181,8 @@
     "measureOn": "Start measuring",
     "measureOff": "Stop measuring",
     "showMovement": "Show move tool",
-    "hideMovement": "Hide move tool"
+    "hideMovement": "Hide move tool",
+    "scale": "Scale:"
   },
   "StitchMenu": {
     "columnCount": "Columns",


### PR DESCRIPTION
Add scale input. I'm not happy with the input field, but I'm not sure how to change it to be better. Anything with a input box is no good for iPad because it pops you out of full screen whenever the input box is focused to display the keyboard. This would be incredibly frustrating to use on iPad since people seem to want to adjust scale on the fly looking at how it will change in real time.