### PR TITLE
Go back into full screen after getting popped out when opening file in certain browsers

### DIFF
--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -145,6 +145,14 @@ export default function Page() {
     if (files && files[0] && isValidPDF(files[0])) {
       setFile(files[0]);
     }
+
+    const expectedContext = localStorage.getItem("calibrationContext");
+    if (expectedContext !== null) {
+      const expected = JSON.parse(expectedContext) as CalibrationContext;
+      if (expected.fullScreen) {
+        fullScreenHandle.enter();
+      }
+    }
   }
 
   // EFFECTS


### PR DESCRIPTION
Doesn't work in Safari of course lol. Works in Chromium browsers though and Firefox never had this issue.