### PR TITLE
Always show stitch menu with export PDF option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Download PDF button that saves the PDF with selected layers and stitched pages
+
+### Changed
+
+- Always show stitch menu button regardless of the number of pages in the PDF
+
 ## [1.0.2] - 2024-05-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Download PDF button that saves the PDF with selected layers and stitched pages
+- Export PDF button that saves the PDF with selected layers and stitched pages
 
 ### Changed
 

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -55,6 +55,7 @@ import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
 import Tooltip from "@/_components/tooltip/tooltip";
 import { IconButton } from "@/_components/buttons/icon-button";
 import FullscreenExitIcon from "@/_icons/fullscreen-exit-icon";
+import SaveButton from "@/_components/save-button";
 
 const defaultStitchSettings = {
   columnCount: 1,
@@ -74,10 +75,10 @@ export default function Page() {
   const [points, dispatch] = useReducer(pointsReducer, []);
   const [stitchSettings, dispatchStitchSettings] = useReducer(
     stitchSettingsReducer,
-    defaultStitchSettings,
+    defaultStitchSettings
   );
   const [displaySettings, setDisplaySettings] = useState<DisplaySettings>(
-    getDefaultDisplaySettings(),
+    getDefaultDisplaySettings()
   );
   const [calibrationValidated, setCalibrationValidated] =
     useState<boolean>(false);
@@ -87,7 +88,7 @@ export default function Page() {
   const [perspective, setPerspective] = useState<Matrix>(Matrix.identity(3, 3));
   const [file, setFile] = useState<File | null>(null);
   const [calibrationTransform, setCalibrationTransform] = useState<Matrix>(
-    Matrix.identity(3, 3),
+    Matrix.identity(3, 3)
   );
   const [pageCount, setPageCount] = useState<number>(1);
   const [unitOfMeasure, setUnitOfMeasure] = useState(IN);
@@ -98,7 +99,7 @@ export default function Page() {
   const [measuring, setMeasuring] = useState<boolean>(false);
 
   const [menuStates, setMenuStates] = useState<MenuStates>(
-    getDefaultMenuStates(),
+    getDefaultMenuStates()
   );
   const [showingMovePad, setShowingMovePad] = useState(false);
   const [corners, setCorners] = useState<Set<number>>(new Set([0]));
@@ -262,14 +263,14 @@ export default function Page() {
         w,
         h,
         ptDensity,
-        true,
+        true
       );
       const n = getPerspectiveTransformFromPoints(
         points,
         w,
         h,
         ptDensity,
-        false,
+        false
       );
       setPerspective(m);
       setCalibrationTransform(n);
@@ -300,7 +301,7 @@ export default function Page() {
           getIsInvalidatedCalibrationContextWithPointerEvent(
             expected,
             e,
-            fullScreenHandle.active,
+            fullScreenHandle.active
           )
         ) {
           setCalibrationValidated(false);
@@ -326,7 +327,7 @@ export default function Page() {
         const expected = JSON.parse(calibrationContext) as CalibrationContext;
         const isInvalid = getIsInvalidatedCalibrationContext(
           expected,
-          fullScreenHandle.active,
+          fullScreenHandle.active
         );
         if (isInvalid === calibrationValidated) {
           setCalibrationValidated(!isInvalid);
@@ -456,8 +457,8 @@ export default function Page() {
                   localStorage.setItem(
                     "calibrationContext",
                     JSON.stringify(
-                      getCalibrationContext(fullScreenHandle.active),
-                    ),
+                      getCalibrationContext(fullScreenHandle.active)
+                    )
                   );
                   dispatch({ type: "set", points: getDefaultPoints() });
                 }}
@@ -498,7 +499,6 @@ export default function Page() {
                   setShowMenu={(showMenu) =>
                     setMenuStates({ ...menuStates, stitch: showMenu })
                   }
-                  file={file}
                   dispatchStitchSettings={dispatchStitchSettings}
                   stitchSettings={stitchSettings}
                   pageCount={pageCount}
@@ -510,6 +510,11 @@ export default function Page() {
                   }
                   layers={layers}
                   setLayers={setLayers}
+                />
+                <SaveButton
+                  file={file}
+                  stitchSettings={stitchSettings}
+                  layers={layers}
                 />
               </menu>
             </menu>

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -55,7 +55,6 @@ import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
 import Tooltip from "@/_components/tooltip/tooltip";
 import { IconButton } from "@/_components/buttons/icon-button";
 import FullscreenExitIcon from "@/_icons/fullscreen-exit-icon";
-import SaveButton from "@/_components/save-button";
 
 const defaultStitchSettings = {
   columnCount: 1,

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -75,10 +75,10 @@ export default function Page() {
   const [points, dispatch] = useReducer(pointsReducer, []);
   const [stitchSettings, dispatchStitchSettings] = useReducer(
     stitchSettingsReducer,
-    defaultStitchSettings
+    defaultStitchSettings,
   );
   const [displaySettings, setDisplaySettings] = useState<DisplaySettings>(
-    getDefaultDisplaySettings()
+    getDefaultDisplaySettings(),
   );
   const [calibrationValidated, setCalibrationValidated] =
     useState<boolean>(false);
@@ -88,7 +88,7 @@ export default function Page() {
   const [perspective, setPerspective] = useState<Matrix>(Matrix.identity(3, 3));
   const [file, setFile] = useState<File | null>(null);
   const [calibrationTransform, setCalibrationTransform] = useState<Matrix>(
-    Matrix.identity(3, 3)
+    Matrix.identity(3, 3),
   );
   const [pageCount, setPageCount] = useState<number>(1);
   const [unitOfMeasure, setUnitOfMeasure] = useState(IN);
@@ -99,7 +99,7 @@ export default function Page() {
   const [measuring, setMeasuring] = useState<boolean>(false);
 
   const [menuStates, setMenuStates] = useState<MenuStates>(
-    getDefaultMenuStates()
+    getDefaultMenuStates(),
   );
   const [showingMovePad, setShowingMovePad] = useState(false);
   const [corners, setCorners] = useState<Set<number>>(new Set([0]));
@@ -263,14 +263,14 @@ export default function Page() {
         w,
         h,
         ptDensity,
-        true
+        true,
       );
       const n = getPerspectiveTransformFromPoints(
         points,
         w,
         h,
         ptDensity,
-        false
+        false,
       );
       setPerspective(m);
       setCalibrationTransform(n);
@@ -301,7 +301,7 @@ export default function Page() {
           getIsInvalidatedCalibrationContextWithPointerEvent(
             expected,
             e,
-            fullScreenHandle.active
+            fullScreenHandle.active,
           )
         ) {
           setCalibrationValidated(false);
@@ -327,7 +327,7 @@ export default function Page() {
         const expected = JSON.parse(calibrationContext) as CalibrationContext;
         const isInvalid = getIsInvalidatedCalibrationContext(
           expected,
-          fullScreenHandle.active
+          fullScreenHandle.active,
         );
         if (isInvalid === calibrationValidated) {
           setCalibrationValidated(!isInvalid);
@@ -457,8 +457,8 @@ export default function Page() {
                   localStorage.setItem(
                     "calibrationContext",
                     JSON.stringify(
-                      getCalibrationContext(fullScreenHandle.active)
-                    )
+                      getCalibrationContext(fullScreenHandle.active),
+                    ),
                   );
                   dispatch({ type: "set", points: getDefaultPoints() });
                 }}

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -69,10 +69,10 @@ export default function Page() {
   const [points, dispatch] = useReducer(pointsReducer, []);
   const [stitchSettings, dispatchStitchSettings] = useReducer(
     stitchSettingsReducer,
-    defaultStitchSettings
+    defaultStitchSettings,
   );
   const [displaySettings, setDisplaySettings] = useState<DisplaySettings>(
-    getDefaultDisplaySettings()
+    getDefaultDisplaySettings(),
   );
   const [calibrationValidated, setCalibrationValidated] =
     useState<boolean>(false);
@@ -82,7 +82,7 @@ export default function Page() {
   const [perspective, setPerspective] = useState<Matrix>(Matrix.identity(3, 3));
   const [file, setFile] = useState<File | null>(null);
   const [calibrationTransform, setCalibrationTransform] = useState<Matrix>(
-    Matrix.identity(3, 3)
+    Matrix.identity(3, 3),
   );
   const [pageCount, setPageCount] = useState<number>(1);
   const [unitOfMeasure, setUnitOfMeasure] = useState(IN);
@@ -93,7 +93,7 @@ export default function Page() {
   const [measuring, setMeasuring] = useState<boolean>(false);
 
   const [menuStates, setMenuStates] = useState<MenuStates>(
-    getDefaultMenuStates()
+    getDefaultMenuStates(),
   );
   const [showingMovePad, setShowingMovePad] = useState(false);
   const [corners, setCorners] = useState<Set<number>>(new Set([0]));
@@ -242,14 +242,14 @@ export default function Page() {
         w,
         h,
         ptDensity,
-        true
+        true,
       );
       const n = getPerspectiveTransformFromPoints(
         points,
         w,
         h,
         ptDensity,
-        false
+        false,
       );
       setPerspective(m);
       setCalibrationTransform(n);
@@ -280,7 +280,7 @@ export default function Page() {
           getIsInvalidatedCalibrationContextWithPointerEvent(
             expected,
             e,
-            fullScreenHandle.active
+            fullScreenHandle.active,
           )
         ) {
           setCalibrationValidated(false);
@@ -306,7 +306,7 @@ export default function Page() {
         const expected = JSON.parse(calibrationContext) as CalibrationContext;
         const isInvalid = getIsInvalidatedCalibrationContext(
           expected,
-          fullScreenHandle.active
+          fullScreenHandle.active,
         );
         if (isInvalid === calibrationValidated) {
           setCalibrationValidated(!isInvalid);
@@ -434,8 +434,8 @@ export default function Page() {
                   localStorage.setItem(
                     "calibrationContext",
                     JSON.stringify(
-                      getCalibrationContext(fullScreenHandle.active)
-                    )
+                      getCalibrationContext(fullScreenHandle.active),
+                    ),
                   );
                   dispatch({ type: "set", points: getDefaultPoints() });
                 }}

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -69,10 +69,10 @@ export default function Page() {
   const [points, dispatch] = useReducer(pointsReducer, []);
   const [stitchSettings, dispatchStitchSettings] = useReducer(
     stitchSettingsReducer,
-    defaultStitchSettings,
+    defaultStitchSettings
   );
   const [displaySettings, setDisplaySettings] = useState<DisplaySettings>(
-    getDefaultDisplaySettings(),
+    getDefaultDisplaySettings()
   );
   const [calibrationValidated, setCalibrationValidated] =
     useState<boolean>(false);
@@ -82,7 +82,7 @@ export default function Page() {
   const [perspective, setPerspective] = useState<Matrix>(Matrix.identity(3, 3));
   const [file, setFile] = useState<File | null>(null);
   const [calibrationTransform, setCalibrationTransform] = useState<Matrix>(
-    Matrix.identity(3, 3),
+    Matrix.identity(3, 3)
   );
   const [pageCount, setPageCount] = useState<number>(1);
   const [unitOfMeasure, setUnitOfMeasure] = useState(IN);
@@ -93,7 +93,7 @@ export default function Page() {
   const [measuring, setMeasuring] = useState<boolean>(false);
 
   const [menuStates, setMenuStates] = useState<MenuStates>(
-    getDefaultMenuStates(),
+    getDefaultMenuStates()
   );
   const [showingMovePad, setShowingMovePad] = useState(false);
   const [corners, setCorners] = useState<Set<number>>(new Set([0]));
@@ -242,14 +242,14 @@ export default function Page() {
         w,
         h,
         ptDensity,
-        true,
+        true
       );
       const n = getPerspectiveTransformFromPoints(
         points,
         w,
         h,
         ptDensity,
-        false,
+        false
       );
       setPerspective(m);
       setCalibrationTransform(n);
@@ -280,7 +280,7 @@ export default function Page() {
           getIsInvalidatedCalibrationContextWithPointerEvent(
             expected,
             e,
-            fullScreenHandle.active,
+            fullScreenHandle.active
           )
         ) {
           setCalibrationValidated(false);
@@ -306,7 +306,7 @@ export default function Page() {
         const expected = JSON.parse(calibrationContext) as CalibrationContext;
         const isInvalid = getIsInvalidatedCalibrationContext(
           expected,
-          fullScreenHandle.active,
+          fullScreenHandle.active
         );
         if (isInvalid === calibrationValidated) {
           setCalibrationValidated(!isInvalid);
@@ -434,8 +434,8 @@ export default function Page() {
                   localStorage.setItem(
                     "calibrationContext",
                     JSON.stringify(
-                      getCalibrationContext(fullScreenHandle.active),
-                    ),
+                      getCalibrationContext(fullScreenHandle.active)
+                    )
                   );
                   dispatch({ type: "set", points: getDefaultPoints() });
                 }}
@@ -476,6 +476,7 @@ export default function Page() {
                   setShowMenu={(showMenu) =>
                     setMenuStates({ ...menuStates, stitch: showMenu })
                   }
+                  file={file}
                   dispatchStitchSettings={dispatchStitchSettings}
                   stitchSettings={stitchSettings}
                   pageCount={pageCount}

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -90,7 +90,7 @@ export default function Page() {
   const [calibrationTransform, setCalibrationTransform] = useState<Matrix>(
     Matrix.identity(3, 3),
   );
-  const [pageCount, setPageCount] = useState<number>(1);
+  const [pageCount, setPageCount] = useState<number>(0);
   const [unitOfMeasure, setUnitOfMeasure] = useState(IN);
   const [layers, setLayers] = useState<Map<string, Layer>>(new Map());
   const [layoutWidth, setLayoutWidth] = useState<number>(0);
@@ -502,6 +502,8 @@ export default function Page() {
                   dispatchStitchSettings={dispatchStitchSettings}
                   stitchSettings={stitchSettings}
                   pageCount={pageCount}
+                  file={file}
+                  layers={layers}
                 />
                 <LayerMenu
                   visible={menuStates.layers}
@@ -510,11 +512,6 @@ export default function Page() {
                   }
                   layers={layers}
                   setLayers={setLayers}
-                />
-                <SaveButton
-                  file={file}
-                  stitchSettings={stitchSettings}
-                  layers={layers}
                 />
               </menu>
             </menu>

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -278,8 +278,6 @@ export default function Header({
           aria-label="Global"
         >
           <div className="flex items-center gap-2">
-            <h1>{isCalibrating ? t("calibrating") : t("projecting")}</h1>
-
             <Tooltip
               description={
                 fullScreenHandle.active ? t("fullscreenExit") : t("fullscreen")
@@ -306,6 +304,31 @@ export default function Header({
                 onClick={() => setMenuStates({ ...menuStates, nav: false })}
               >
                 <ExpandLessIcon ariaLabel={t("menuHide")} />
+              </IconButton>
+            </Tooltip>
+            <Tooltip
+              description={
+                menuStates.stitch
+                  ? t("stitchMenuHide")
+                  : pageCount === 0
+                    ? t("stitchMenuDisabled")
+                    : t("stitchMenuShow")
+              }
+            >
+              <IconButton
+                disabled={pageCount === 0}
+                onClick={() =>
+                  setMenuStates({ ...menuStates, stitch: !menuStates.stitch })
+                }
+                className={`${menuStates.stitch ? "!bg-gray-300 dark:!bg-gray-600" : ""} ${visible(!isCalibrating)}`}
+              >
+                <FlexWrapIcon
+                  ariaLabel={
+                    menuStates.stitch
+                      ? t("stitchMenuHide")
+                      : t("stitchMenuShow")
+                  }
+                />
               </IconButton>
             </Tooltip>
             <Tooltip description={t("invertColor")}>
@@ -346,6 +369,16 @@ export default function Header({
                     },
                   });
                 }}
+              />
+            )}
+            {!isCalibrating && (
+              <DropdownIconButton
+                dropdownClassName="w-fit -left-5"
+                description={t("lineWeight")}
+                icon={<LineWeightIcon ariaLabel={t("lineWeight")} />}
+                options={lineThicknessOptions}
+                setSelection={setLineThickness}
+                selection={lineThickness}
               />
             )}
           </div>
@@ -412,41 +445,6 @@ export default function Header({
             </Tooltip>
           </div>
           <div className={`flex items-center gap-2 ${visible(!isCalibrating)}`}>
-            <Tooltip
-              description={
-                menuStates.stitch ? t("stitchMenuHide") : t("stitchMenuShow")
-              }
-              className={`${visible(pageCount > 1)}`}
-            >
-              <IconButton
-                onClick={() =>
-                  setMenuStates({ ...menuStates, stitch: !menuStates.stitch })
-                }
-                className={
-                  menuStates.stitch ? "!bg-gray-300 dark:!bg-gray-600" : ""
-                }
-              >
-                <FlexWrapIcon
-                  ariaLabel={
-                    menuStates.stitch
-                      ? t("stitchMenuHide")
-                      : t("stitchMenuShow")
-                  }
-                />
-              </IconButton>
-            </Tooltip>
-
-            {!isCalibrating && (
-              <DropdownIconButton
-                dropdownClassName="w-fit -left-5"
-                description={t("lineWeight")}
-                icon={<LineWeightIcon ariaLabel={t("lineWeight")} />}
-                options={lineThicknessOptions}
-                setSelection={setLineThickness}
-                selection={lineThickness}
-              />
-            )}
-
             <Tooltip description={t("flipHorizontal")}>
               <IconButton onClick={handleFlipHorizontal}>
                 <FlipVerticalIcon ariaLabel={t("flipHorizontal")} />

--- a/app/_components/input.tsx
+++ b/app/_components/input.tsx
@@ -35,9 +35,9 @@ export default function Input({
   inputRef?: LegacyRef<HTMLInputElement> | undefined;
 }) {
   return (
-    <div className={className}>
+    <div className={`${className} flex flex-col`}>
       <label
-        className="text-sm font-medium text-gray-500 dark:text-white mr-1"
+        className="text-sm font-medium text-gray-500 dark:text-white ml-1"
         htmlFor={id}
       >
         {label}

--- a/app/_components/save-button.tsx
+++ b/app/_components/save-button.tsx
@@ -1,0 +1,67 @@
+import { Layer } from "@/_lib/interfaces/layer";
+import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
+import { savePDF } from "@/_lib/pdfstitcher";
+import { useTranslations } from "next-intl";
+import PdfIcon from "@/_icons/pdf-icon";
+
+export default function SaveButton({
+  file,
+  stitchSettings,
+  layers,
+}: {
+  file: File | null;
+  stitchSettings: StitchSettings;
+  layers: Map<string, Layer>;
+}) {
+  const t = useTranslations("SaveMenu");
+
+  async function handleSave() {
+    if (file === null) return;
+
+    function saveFileSuccess(pdfBytes: Uint8Array) {
+      const blob = new Blob([pdfBytes], { type: "application/pdf" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download =
+        file?.name.replace(".pdf", "-stitched.pdf") ?? "stitched.pdf";
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+
+    function stitchFileError(e: Error | any) {
+      if (
+        (e instanceof Error && e.message.includes("encrypted")) ||
+        e.message.includes("password")
+      ) {
+        const response = prompt(t("encryptedPDF"));
+        // User cancelled, do nothing
+        if (response === null || file === null) return;
+        savePDF(file, stitchSettings, layers, response).then(saveFileSuccess);
+      } else {
+        console.error(e);
+      }
+    }
+
+    savePDF(file, stitchSettings, layers)
+      .then(saveFileSuccess)
+      .catch(stitchFileError);
+  }
+
+  return (
+    <>
+      <button
+        className="flex gap-2 items-center outline outline-purple-600 text-purple-600 focus:ring-2 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800  hover:bg-purple-600 hover:text-white font-medium rounded-lg text-sm px-2 py-1.5 hover:bg-none text-center"
+        onClick={handleSave}
+        style={{
+          position: "fixed",
+          bottom: "10px",
+          left: "10px",
+        }}
+      >
+        <PdfIcon ariaLabel={t("save")} fill="currentColor" />
+        {t("save")}
+      </button>
+    </>
+  );
+}

--- a/app/_components/save-button.tsx
+++ b/app/_components/save-button.tsx
@@ -2,7 +2,8 @@ import { Layer } from "@/_lib/interfaces/layer";
 import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
 import { savePDF } from "@/_lib/pdfstitcher";
 import { useTranslations } from "next-intl";
-import PdfIcon from "@/_icons/pdf-icon";
+import DownloadIcon from "@/_icons/download-icon";
+import Tooltip from "./tooltip/tooltip";
 
 export default function SaveButton({
   file,
@@ -49,19 +50,14 @@ export default function SaveButton({
   }
 
   return (
-    <>
+    <Tooltip description={t("saveTooltip")}>
       <button
-        className="flex gap-2 items-center outline outline-purple-600 text-purple-600 focus:ring-2 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800  hover:bg-purple-600 hover:text-white font-medium rounded-lg text-sm px-2 py-1.5 hover:bg-none text-center"
+        className="flex h-11 gap-2 items-center outline outline-purple-600 text-purple-600 focus:ring-2 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 hover:bg-purple-600 hover:text-white font-medium rounded-lg text-sm px-2 py-1.5 hover:bg-none text-center"
         onClick={handleSave}
-        style={{
-          position: "fixed",
-          bottom: "10px",
-          left: "10px",
-        }}
       >
-        <PdfIcon ariaLabel={t("save")} fill="currentColor" />
+        <DownloadIcon ariaLabel={t("save")} />
         {t("save")}
       </button>
-    </>
+    </Tooltip>
   );
 }

--- a/app/_components/stepper-input.tsx
+++ b/app/_components/stepper-input.tsx
@@ -52,40 +52,42 @@ export default function StepperInput({
     "rounded-none h-11 p-2.5 bg-gray-50 border border-gray-300 text-gray-900 text-sm focus:ring-4 focus:outline-none focus:ring-blue-300 w-12 text-center dark:bg-black dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-800 dark:focus:border-blue-800";
 
   return (
-    <div className="flex items-center justify-center">
+    <div className="flex flex-col">
       <label
         style={{ WebkitUserSelect: "none", userSelect: "none" }}
-        className="text-sm font-medium text-gray-900 dark:text-white mr-1 user-select-none"
+        className="text-sm font-medium text-gray-900 dark:text-white ml-1 user-select-none"
         htmlFor={name}
       >
         {label}
       </label>
-      <button
-        style={{ WebkitUserSelect: "none", userSelect: "none" }}
-        className={`${buttonClassName} rounded-s-lg`}
-        onPointerDown={() => handleStep(-1)}
-        onPointerUp={handleButtonRelease}
-        onPointerLeave={handleButtonRelease}
-      >
-        <StepDownIcon ariaLabel="decrement" />
-      </button>
-      <input
-        onChange={handleChange}
-        inputMode="numeric"
-        value={value}
-        name={name}
-        id={name}
-        className={`${inputClassName} ${inputClass}`}
-      />
-      <button
-        style={{ WebkitUserSelect: "none", userSelect: "none" }}
-        className={`${buttonClassName} rounded-e-lg`}
-        onPointerDown={() => handleStep(1)}
-        onPointerUp={handleButtonRelease}
-        onPointerLeave={handleButtonRelease}
-      >
-        <StepUpIcon ariaLabel="increment" />
-      </button>
+      <div className="flex items-center justify-center">
+        <button
+          style={{ WebkitUserSelect: "none", userSelect: "none" }}
+          className={`${buttonClassName} rounded-s-lg`}
+          onPointerDown={() => handleStep(-1)}
+          onPointerUp={handleButtonRelease}
+          onPointerLeave={handleButtonRelease}
+        >
+          <StepDownIcon ariaLabel="decrement" />
+        </button>
+        <input
+          onChange={handleChange}
+          inputMode="numeric"
+          value={value}
+          name={name}
+          id={name}
+          className={`${inputClassName} ${inputClass}`}
+        />
+        <button
+          style={{ WebkitUserSelect: "none", userSelect: "none" }}
+          className={`${buttonClassName} rounded-e-lg`}
+          onPointerDown={() => handleStep(1)}
+          onPointerUp={handleButtonRelease}
+          onPointerLeave={handleButtonRelease}
+        >
+          <StepUpIcon ariaLabel="increment" />
+        </button>
+      </div>
     </div>
   );
 }

--- a/app/_components/stitch-menu.tsx
+++ b/app/_components/stitch-menu.tsx
@@ -7,14 +7,18 @@ import StepperInput from "@/_components/stepper-input";
 import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
 import { StitchSettingsAction } from "@/_reducers/stitchSettingsReducer";
 import { allowInteger } from "@/_lib/remove-non-digits";
+import PdfIcon from "@/_icons/pdf-icon";
+import { saveStitchedPDF } from "@/_lib/pdfstitcher";
 
 export default function StitchMenu({
+  file,
   dispatchStitchSettings,
   stitchSettings,
   pageCount,
   className,
   setShowMenu,
 }: {
+  file: File | null;
   dispatchStitchSettings: Dispatch<StitchSettingsAction>;
   stitchSettings: StitchSettings;
   pageCount: number;
@@ -33,6 +37,24 @@ export default function StitchMenu({
       edgeInsets.vertical = inset;
     }
     dispatchStitchSettings({ type: "set-edge-insets", edgeInsets });
+  }
+
+  function handleSaveChange(e: React.MouseEvent<HTMLButtonElement>) {
+    if (file === null) return;
+
+    // Try saving stitched PDF, prompting for password if necessary.
+    try {
+      saveStitchedPDF(file, stitchSettings, pageCount);
+    } catch (e: Error | any) {
+      if (e instanceof Error && e.message === "Invalid password") {
+        const response = prompt(t("encryptedPDF"));
+        // User cancelled, do nothing
+        if (response === null) return;
+        saveStitchedPDF(file, stitchSettings, pageCount, response);
+      } else {
+        console.error(e);
+      }
+    }
   }
 
   return (
@@ -108,6 +130,13 @@ export default function StitchMenu({
             dispatchStitchSettings({ type: "step-vertical", step: increment })
           }
         />
+        <button
+          className="flex gap-2 items-center outline outline-purple-600 text-purple-600 focus:ring-2 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800  hover:bg-purple-600 hover:text-white font-medium rounded-lg text-sm px-2 py-1.5 hover:bg-none text-center"
+          onClick={handleSaveChange}
+        >
+          <PdfIcon ariaLabel={t("save")} fill="currentColor" />
+          {t("save")}
+        </button>
       </div>
       <IconButton onClick={() => setShowMenu(false)}>
         <CloseIcon ariaLabel="close" />

--- a/app/_components/stitch-menu.tsx
+++ b/app/_components/stitch-menu.tsx
@@ -7,18 +7,14 @@ import StepperInput from "@/_components/stepper-input";
 import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
 import { StitchSettingsAction } from "@/_reducers/stitchSettingsReducer";
 import { allowInteger } from "@/_lib/remove-non-digits";
-import PdfIcon from "@/_icons/pdf-icon";
-import { saveStitchedPDF } from "@/_lib/pdfstitcher";
 
 export default function StitchMenu({
-  file,
   dispatchStitchSettings,
   stitchSettings,
   pageCount,
   className,
   setShowMenu,
 }: {
-  file: File | null;
   dispatchStitchSettings: Dispatch<StitchSettingsAction>;
   stitchSettings: StitchSettings;
   pageCount: number;
@@ -37,36 +33,6 @@ export default function StitchMenu({
       edgeInsets.vertical = inset;
     }
     dispatchStitchSettings({ type: "set-edge-insets", edgeInsets });
-  }
-
-  function stitchFileSuccess(pdfBytes: Uint8Array) {
-    const blob = new Blob([pdfBytes], { type: "application/pdf" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = file?.name.replace(".pdf", "-stitched.pdf") ?? "stitched.pdf";
-    a.click();
-    URL.revokeObjectURL(url);
-  }
-
-  function handleSaveChange() {
-    if (file === null) return;
-
-    // Try saving stitched PDF, prompting for password if necessary.
-    try {
-      saveStitchedPDF(file, stitchSettings, pageCount).then(stitchFileSuccess);
-    } catch (e: Error | any) {
-      if (e instanceof Error && e.message === "Invalid password") {
-        const response = prompt(t("encryptedPDF"));
-        // User cancelled, do nothing
-        if (response === null) return;
-        saveStitchedPDF(file, stitchSettings, pageCount, response).then(
-          stitchFileSuccess,
-        );
-      } else {
-        console.error(e);
-      }
-    }
   }
 
   return (
@@ -142,13 +108,6 @@ export default function StitchMenu({
             dispatchStitchSettings({ type: "step-vertical", step: increment })
           }
         />
-        <button
-          className="flex gap-2 items-center outline outline-purple-600 text-purple-600 focus:ring-2 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800  hover:bg-purple-600 hover:text-white font-medium rounded-lg text-sm px-2 py-1.5 hover:bg-none text-center"
-          onClick={handleSaveChange}
-        >
-          <PdfIcon ariaLabel={t("save")} fill="currentColor" />
-          {t("save")}
-        </button>
       </div>
       <IconButton onClick={() => setShowMenu(false)}>
         <CloseIcon ariaLabel="close" />

--- a/app/_components/stitch-menu.tsx
+++ b/app/_components/stitch-menu.tsx
@@ -49,7 +49,7 @@ export default function StitchMenu({
     URL.revokeObjectURL(url);
   }
 
-  function handleSaveChange(e: React.MouseEvent<HTMLButtonElement>) {
+  function handleSaveChange() {
     if (file === null) return;
 
     // Try saving stitched PDF, prompting for password if necessary.
@@ -61,7 +61,7 @@ export default function StitchMenu({
         // User cancelled, do nothing
         if (response === null) return;
         saveStitchedPDF(file, stitchSettings, pageCount, response).then(
-          stitchFileSuccess
+          stitchFileSuccess,
         );
       } else {
         console.error(e);

--- a/app/_components/stitch-menu.tsx
+++ b/app/_components/stitch-menu.tsx
@@ -39,18 +39,30 @@ export default function StitchMenu({
     dispatchStitchSettings({ type: "set-edge-insets", edgeInsets });
   }
 
+  function stitchFileSuccess(pdfBytes: Uint8Array) {
+    const blob = new Blob([pdfBytes], { type: "application/pdf" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = file?.name.replace(".pdf", "-stitched.pdf") ?? "stitched.pdf";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
   function handleSaveChange(e: React.MouseEvent<HTMLButtonElement>) {
     if (file === null) return;
 
     // Try saving stitched PDF, prompting for password if necessary.
     try {
-      saveStitchedPDF(file, stitchSettings, pageCount);
+      saveStitchedPDF(file, stitchSettings, pageCount).then(stitchFileSuccess);
     } catch (e: Error | any) {
       if (e instanceof Error && e.message === "Invalid password") {
         const response = prompt(t("encryptedPDF"));
         // User cancelled, do nothing
         if (response === null) return;
-        saveStitchedPDF(file, stitchSettings, pageCount, response);
+        saveStitchedPDF(file, stitchSettings, pageCount, response).then(
+          stitchFileSuccess
+        );
       } else {
         console.error(e);
       }

--- a/app/_components/stitch-menu.tsx
+++ b/app/_components/stitch-menu.tsx
@@ -7,6 +7,8 @@ import StepperInput from "@/_components/stepper-input";
 import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
 import { StitchSettingsAction } from "@/_reducers/stitchSettingsReducer";
 import { allowInteger } from "@/_lib/remove-non-digits";
+import SaveButton from "./save-button";
+import { Layer } from "@/_lib/interfaces/layer";
 
 export default function StitchMenu({
   dispatchStitchSettings,
@@ -14,12 +16,16 @@ export default function StitchMenu({
   pageCount,
   className,
   setShowMenu,
+  file,
+  layers,
 }: {
   dispatchStitchSettings: Dispatch<StitchSettingsAction>;
   stitchSettings: StitchSettings;
   pageCount: number;
   className?: string;
   setShowMenu: (showMenu: boolean) => void;
+  file: File | null;
+  layers: Map<string, Layer>;
 }) {
   const t = useTranslations("StitchMenu");
 
@@ -37,9 +43,9 @@ export default function StitchMenu({
 
   return (
     <menu
-      className={`${className ?? ""} flex justify-between left-0 w-full transition-all duration-700 bg-white dark:bg-black border-b border-gray-200 dark:border-gray-700 p-2`}
+      className={`${className ?? ""} flex justify-between items-center left-0 w-full transition-all duration-700 bg-white dark:bg-black border-b border-gray-200 dark:border-gray-700 p-2`}
     >
-      <div className="flex gap-4">
+      <div className="flex gap-4 items-end">
         <Input
           inputClassName="w-36"
           handleChange={(e) =>
@@ -108,8 +114,13 @@ export default function StitchMenu({
             dispatchStitchSettings({ type: "step-vertical", step: increment })
           }
         />
+        <SaveButton
+          file={file}
+          stitchSettings={stitchSettings}
+          layers={layers}
+        />
       </div>
-      <IconButton onClick={() => setShowMenu(false)}>
+      <IconButton onClick={() => setShowMenu(false)} className="h-11">
         <CloseIcon ariaLabel="close" />
       </IconButton>
     </menu>

--- a/app/_icons/download-icon.tsx
+++ b/app/_icons/download-icon.tsx
@@ -1,0 +1,14 @@
+export default function DownloadIcon({ ariaLabel }: { ariaLabel: string }) {
+  return (
+    <svg
+      aria-label={ariaLabel}
+      xmlns="http://www.w3.org/2000/svg"
+      height="24px"
+      viewBox="0 -960 960 960"
+      width="24px"
+      fill="currentColor"
+    >
+      <path d="M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160H240Z" />
+    </svg>
+  );
+}

--- a/app/_lib/pdfstitcher.ts
+++ b/app/_lib/pdfstitcher.ts
@@ -1,4 +1,9 @@
-import { PDFDocument } from "@cantoo/pdf-lib";
+import {
+  PDFDocument,
+  PDFName,
+  PDFObjectCopier,
+  PDFObject,
+} from "@cantoo/pdf-lib";
 import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
 import { getPageNumbers } from "./get-page-numbers";
 
@@ -21,6 +26,23 @@ function trimmedPageSize(
   return { width: width, height: height };
 }
 
+async function initNewDoc(inDoc: PDFDocument) {
+  /**
+   * Creates a new document, copying over metadata and various other
+   * properties (especially layer info)
+   */
+  const outDoc = await PDFDocument.create();
+  const copier = PDFObjectCopier.for(inDoc.context, outDoc.context);
+  const pagesKey = PDFName.of("Pages");
+  for (const [key, value] of inDoc.catalog.entries()) {
+    if (key != pagesKey) {
+      outDoc.catalog.set(key, copier.copy(value));
+    }
+  }
+
+  return outDoc;
+}
+
 export async function saveStitchedPDF(
   file: File,
   settings: StitchSettings,
@@ -30,10 +52,12 @@ export async function saveStitchedPDF(
   // Grab the bytes from the file object and try to load the PDF
   // Error handling is done in the calling function.
   const pdfBytes = await file.arrayBuffer();
-  const doc = await PDFDocument.load(pdfBytes, {
+  const inDoc = await PDFDocument.load(pdfBytes, {
     ignoreEncryption: true,
     password,
   });
+
+  const outDoc = await initNewDoc(inDoc);
 
   // Trust that the user is happy with the layout
   const pages = getPageNumbers(settings.pageRange, pageCount);
@@ -42,14 +66,14 @@ export async function saveStitchedPDF(
   const trim = settings.edgeInsets;
 
   // Compute the size of the output document
-  const pageSize = trimmedPageSize(doc, pages, settings);
+  const pageSize = trimmedPageSize(inDoc, pages, settings);
   const outWidth = pageSize.width * cols;
   const outHeight = pageSize.height * rows;
 
   // Create a new page to hold the stitched pages
   // Add at least a 1" margin because of weirdness.
   const margin = Math.max(trim.horizontal, trim.vertical, 72);
-  const outPage = doc.addPage([outWidth, outHeight]);
+  const outPage = outDoc.addPage();
   outPage.setMediaBox(
     -margin,
     -margin,
@@ -59,25 +83,21 @@ export async function saveStitchedPDF(
 
   // Loop through the pages and copy them to the output document
   let x = 0;
-  let y = outHeight - pageSize.height - margin;
+  let y = outHeight - pageSize.height;
+
   for (const p of pages) {
     if (p > 0) {
-      const xobject = await doc.embedPage(doc.getPage(p - 1));
+      const xobject = await outDoc.embedPage(inDoc.getPage(p - 1));
       outPage.drawPage(xobject, { x: x, y: y });
     }
     // Adjust the position for the next page
     x += pageSize.width;
-    if (x >= outWidth) {
+    if (x > outWidth - margin) {
       x = 0;
       y -= pageSize.height;
     }
   }
 
-  // remove all the original pages except the last one
-  while (doc.getPageCount() > 1) {
-    doc.removePage(0);
-  }
-
   // Save the stitched document
-  return await doc.save();
+  return await outDoc.save();
 }

--- a/app/_lib/pdfstitcher.ts
+++ b/app/_lib/pdfstitcher.ts
@@ -5,7 +5,7 @@ import { getPageNumbers } from "./get-page-numbers";
 function trimmedPageSize(
   inDoc: PDFDocument,
   pages: number[],
-  settings: StitchSettings
+  settings: StitchSettings,
 ) {
   /**
    * Computes the size for each trimmed page.
@@ -25,12 +25,12 @@ export async function saveStitchedPDF(
   file: File,
   settings: StitchSettings,
   pageCount: number,
-  password: string = ""
+  password: string = "",
 ) {
   // Grab the bytes from the file object and try to load the PDF
   // Error handling is done in the calling function.
   const pdfBytes = await file.arrayBuffer();
-  let inDoc = await PDFDocument.load(pdfBytes, {
+  const inDoc = await PDFDocument.load(pdfBytes, {
     ignoreEncryption: true,
     password,
   });
@@ -51,7 +51,12 @@ export async function saveStitchedPDF(
   const margin = Math.max(trim.horizontal, trim.vertical, 72);
   const outDoc = await PDFDocument.create();
   const outPage = outDoc.addPage([outWidth, outHeight]);
-  outPage.setMediaBox(-margin, -margin, outWidth + margin * 2, outHeight + margin * 2)
+  outPage.setMediaBox(
+    -margin,
+    -margin,
+    outWidth + margin * 2,
+    outHeight + margin * 2,
+  );
 
   // Loop through the pages and copy them to the output document
   let x = 0;
@@ -59,7 +64,7 @@ export async function saveStitchedPDF(
   for (const p of pages) {
     if (p > 0) {
       const xobject = await outDoc.embedPage(inDoc.getPage(p - 1));
-      outPage.drawPage(xobject, {x: x, y: y});
+      outPage.drawPage(xobject, { x: x, y: y });
     }
     // Adjust the position for the next page
     x += pageSize.width;
@@ -70,5 +75,5 @@ export async function saveStitchedPDF(
   }
 
   // Save the stitched document
-  return await outDoc.save()
+  return await outDoc.save();
 }

--- a/app/_lib/pdfstitcher.ts
+++ b/app/_lib/pdfstitcher.ts
@@ -16,7 +16,6 @@ import {
   PDFRawStream,
   decodePDFRawStream,
   UnrecognizedStreamTypeError,
-  PDFObject,
 } from "@cantoo/pdf-lib";
 import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
 import { getPageNumbers } from "./get-page-numbers";
@@ -168,15 +167,15 @@ function toggleLayers(doc: PDFDocument, layers: Map<string, Layer>) {
   const ocprops = getAsDict("OCProperties", doc.catalog);
   if (!ocprops) return; // sometimes the document doesn't have layers
 
-  let D = getAsDict("D", ocprops) ?? doc.context.obj({});
+  const D = getAsDict("D", ocprops) ?? doc.context.obj({});
   ocprops.set(PDFName.of("D"), D);
 
-  const visible : PDFArray = doc.context.obj([]);
-  const hidden : PDFArray = doc.context.obj([]);
+  const visible: PDFArray = doc.context.obj([]);
+  const hidden: PDFArray = doc.context.obj([]);
 
   for (const layer of layers.values()) {
     const refs = layer.ids.map((id) => PDFRef.of(parseInt(id)));
-    refs.map((r) => layer.visible ? visible.push(r) : hidden.push(r));
+    refs.map((r) => (layer.visible ? visible.push(r) : hidden.push(r)));
   }
 
   D.set(PDFName.of("ON"), visible);

--- a/app/_lib/pdfstitcher.ts
+++ b/app/_lib/pdfstitcher.ts
@@ -19,6 +19,7 @@ import {
 } from "@cantoo/pdf-lib";
 import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
 import { getPageNumbers } from "./get-page-numbers";
+import { Layer } from "./interfaces/layer";
 
 function trimmedPageSize(
   inDoc: PDFDocument,
@@ -147,10 +148,10 @@ function getFormXObjectForPage(
   return context.register(xObject);
 }
 
-export async function saveStitchedPDF(
+export async function savePDF(
   file: File,
   settings: StitchSettings,
-  pageCount: number,
+  layers: Map<string, Layer>,
   password: string = "",
 ) {
   // Grab the bytes from the file object and try to load the PDF
@@ -162,7 +163,7 @@ export async function saveStitchedPDF(
   });
 
   // Trust that the user is happy with the layout
-  const pages = getPageNumbers(settings.pageRange, pageCount);
+  const pages = getPageNumbers(settings.pageRange, doc.getPageCount());
   const cols = settings.columnCount;
   const rows = Math.ceil(pages.length / cols);
   const trim = settings.edgeInsets;

--- a/app/_lib/pdfstitcher.ts
+++ b/app/_lib/pdfstitcher.ts
@@ -2,6 +2,7 @@ import {
   PDFDocument,
   PDFName,
   PDFRef,
+  PDFPage,
   PDFPageLeaf,  
   PDFOperator,
   concatTransformationMatrix,
@@ -54,7 +55,7 @@ function getFormXObjectForPage(doc: PDFDocument, ref: PDFRef): PDFRef | undefine
   const page = doc.context.lookup(ref) as PDFPageLeaf | undefined;
   if (!page) return undefined;
 
-  // create a new form XObject
+  // Create a new form XObject
   const xObject = doc.context.obj({});
   xObject.set(PDFName.of("Type"), PDFName.of("XObject"));
   xObject.set(PDFName.of("Subtype"), PDFName.of("Form"));
@@ -122,6 +123,7 @@ export async function saveStitchedPDF(
 
   for (const p of pages) {
     if (p > 0) {
+      // create a new form XObject for the page
       const xRef = await getFormXObjectForPage(outDoc, inDoc.getPage(p - 1).ref);
       if (!xRef) {
         throw new Error(`Failed to create form XObject for page ${p}`);

--- a/app/_lib/pdfstitcher.ts
+++ b/app/_lib/pdfstitcher.ts
@@ -1,0 +1,23 @@
+import { PDFDocument } from "@cantoo/pdf-lib";
+import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
+import { getPageNumbers } from "./get-page-numbers";
+import { PDF_TO_CSS_UNITS } from "@/_lib/pixels-per-inch";
+
+export async function saveStitchedPDF(
+  file: File,
+  settings: StitchSettings,
+  pageCount: number,
+  password: string = ""
+) {
+
+  const pageRange = getPageNumbers(settings.pageRange, pageCount);
+
+  // Grab the bytes from the file object and try to load the PDF
+  const pdfBytes = await file.arrayBuffer();
+  let inDoc = await PDFDocument.load(pdfBytes, { ignoreEncryption: true, password });
+
+  // Print out some info to make sure it's working
+  console.log(inDoc.getPage(0).getTrimBox());
+
+  const outDoc = PDFDocument.create();
+}

--- a/app/_lib/pdfstitcher.ts
+++ b/app/_lib/pdfstitcher.ts
@@ -1,9 +1,4 @@
-import {
-  PDFDocument,
-  PDFName,
-  PDFObjectCopier,
-  PDFObject,
-} from "@cantoo/pdf-lib";
+import { PDFDocument, PDFName, PDFObjectCopier } from "@cantoo/pdf-lib";
 import { StitchSettings } from "@/_lib/interfaces/stitch-settings";
 import { getPageNumbers } from "./get-page-numbers";
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -185,7 +185,9 @@
     "columnCount": "Columns",
     "pageRange": "Stitch Pages",
     "horizontal": "Horizontal",
-    "vertical": "Vertical"
+    "vertical": "Vertical",
+    "save": "Save PDF",
+    "encryptedPDF": "This PDF is encrypted. Please enter the password to save the stitched PDF."
   },
   "LayerMenu": {
     "title": "Layers",

--- a/messages/en.json
+++ b/messages/en.json
@@ -187,8 +187,6 @@
     "ok": "OK"
   },
   "Header": {
-    "projecting": "Projecting",
-    "calibrating": "Calibrating",
     "openPDF": "Open PDF",
     "height": "H:",
     "width": "W:",
@@ -230,6 +228,7 @@
     "lineWeight": "Line weight",
     "stitchMenuShow": "Show stitch menu",
     "stitchMenuHide": "Hide stitch menu",
+    "stitchMenuDisabled": "Open PDF to use stitch menu",
     "measure": "Line tool (L)",
     "showMovement": "Show move tool",
     "hideMovement": "Hide move tool"
@@ -241,7 +240,8 @@
     "vertical": "Vertical"
   },
   "SaveMenu": {
-    "save": "Save PDF",
+    "save": "Download PDF",
+    "saveTooltip": "Download PDF with stitched pages and selected layers",
     "encryptedPDF": "This PDF is encrypted. Please enter the password to save the stitched PDF."
   },
   "LayerMenu": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -238,7 +238,9 @@
     "columnCount": "Columns",
     "pageRange": "Stitch Pages",
     "horizontal": "Horizontal",
-    "vertical": "Vertical",
+    "vertical": "Vertical"
+  },
+  "SaveMenu": {
     "save": "Save PDF",
     "encryptedPDF": "This PDF is encrypted. Please enter the password to save the stitched PDF."
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -240,8 +240,8 @@
     "vertical": "Vertical"
   },
   "SaveMenu": {
-    "save": "Download PDF",
-    "saveTooltip": "Download PDF with stitched pages and selected layers",
+    "save": "Export PDF",
+    "saveTooltip": "Export PDF with stitched pages and selected layers",
     "encryptedPDF": "This PDF is encrypted. Please enter the password to save the stitched PDF."
   },
   "LayerMenu": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
+    "@cantoo/pdf-lib": "^2.1.3",
     "@serwist/next": "^8.4.4",
     "@serwist/precaching": "^8.4.4",
     "@serwist/sw": "^8.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,9 +330,9 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@cantoo/pdf-lib@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@cantoo/pdf-lib/-/pdf-lib-2.1.3.tgz#170b5b6f62b3b6630bfdd9b104f244af839aad09"
-  integrity sha512-OdwJ0mtjlITWVQ7VkbX/mc7T3Wlq4OkYtlMLd8I3QlK1V7YALgHjhEGg6AqIeqBLfwYJRExNSDp6GOH216vEbg==
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@cantoo/pdf-lib/-/pdf-lib-2.1.5.tgz#941268a9e8e7ce20c0f43e902802ab37a34ef5f4"
+  integrity sha512-81w9WSZf/kIvxe4wPADjip9i/Kioz4VEERm3mzmrI5z1lk5rxb5PFuZXPBB/0d1Ah7q1V6oeru9PFxK+2LMZ4w==
   dependencies:
     "@pdf-lib/standard-fonts" "^1.0.0"
     "@pdf-lib/upng" "^1.0.1"
@@ -5343,9 +5343,9 @@ node-fetch@^2.6.7:
     whatwg-url "^5.0.0"
 
 node-html-better-parser@^1.4.0:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/node-html-better-parser/-/node-html-better-parser-1.4.3.tgz#b0aff7771094541e1ccc97fa3f612709fc303779"
-  integrity sha512-Ks/yImEI7A5Yav3p0ecyH2/q3YOllFQ4BQUgk8I/BZgISdXNMhNHQhX7D5kjHQhd6oMok0f9FUaHNFJBVqylHw==
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/node-html-better-parser/-/node-html-better-parser-1.4.4.tgz#3db04fe71db3c9c883f60b2da33c538818832057"
+  integrity sha512-uvlqL1uMU7m/aIY9WsGM0jDW7gVFIuFSWS6f2rlJeL7K1ZzKnA3B8cNbUGw9ywwYm9W7W2ooi0iQ7aI29aQmPw==
   dependencies:
     html-entities "^2.3.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,6 +329,17 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cantoo/pdf-lib@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@cantoo/pdf-lib/-/pdf-lib-2.1.3.tgz#170b5b6f62b3b6630bfdd9b104f244af839aad09"
+  integrity sha512-OdwJ0mtjlITWVQ7VkbX/mc7T3Wlq4OkYtlMLd8I3QlK1V7YALgHjhEGg6AqIeqBLfwYJRExNSDp6GOH216vEbg==
+  dependencies:
+    "@pdf-lib/standard-fonts" "^1.0.0"
+    "@pdf-lib/upng" "^1.0.1"
+    color "^4.2.3"
+    node-html-better-parser "^1.4.0"
+    pako "^1.0.11"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -833,6 +844,20 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@pdf-lib/standard-fonts@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz#8ba691c4421f71662ed07c9a0294b44528af2d7f"
+  integrity sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==
+  dependencies:
+    pako "^1.0.6"
+
+"@pdf-lib/upng@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/upng/-/upng-1.0.1.tgz#7dc9c636271aca007a9df4deaf2dd7e7960280cb"
+  integrity sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==
+  dependencies:
+    pako "^1.0.10"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -2415,15 +2440,31 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
 
 color-support@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colorette@^2.0.16:
   version "2.0.20"
@@ -3836,6 +3877,11 @@ html-encoding-sniffer@^3.0.0:
   dependencies:
     whatwg-encoding "^2.0.0"
 
+html-entities@^2.3.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.5.2.tgz#201a3cf95d3a15be7099521620d19dfb4f65359f"
+  integrity sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -3987,6 +4033,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-async-function@^2.0.0:
   version "2.0.0"
@@ -5291,6 +5342,13 @@ node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-html-better-parser@^1.4.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/node-html-better-parser/-/node-html-better-parser-1.4.3.tgz#b0aff7771094541e1ccc97fa3f612709fc303779"
+  integrity sha512-Ks/yImEI7A5Yav3p0ecyH2/q3YOllFQ4BQUgk8I/BZgISdXNMhNHQhX7D5kjHQhd6oMok0f9FUaHNFJBVqylHw==
+  dependencies:
+    html-entities "^2.3.2"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -5512,6 +5570,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+pako@^1.0.10, pako@^1.0.11, pako@^1.0.6:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -6258,6 +6321,13 @@ simple-get@^3.0.3:
     decompress-response "^4.2.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have run `yarn build` to ensure that the project builds successfully.
- [x] I have updated `CHANGELOG.md` with the necessary changes made in this pull request.

## Description

- Changed save to export
- Moved stitch input labels above boxes to make more room horizontally
- Added tooltip to export button
- Always show stitch menu button regardless of page count (disabled until PDF is opened)
- Removed "projecting/calibrating" label from menu to make more room
- It's possible to press all buttons in the menu, stitch, and layers menu on an iPhone SE when in landscape. Bad UX but at least it's possible
- I decided not to add an experimental tooltip since it's working really well! I think people get that anything new we put out will have some issues.

Making the stitch menu always available and having the export button in there is the best solution I could come up with for always having the button available while working within space constraints. I think it also makes sense to keep that functionality together, like a mini pdfstitcher in PP. That way if/when we pull it out it's all together.

Please let me know what you think @sashasewist and @cfcurtis. Sorry for taking so long to get this out! Also, @cfcurtis would you be ok with me adding you to the project?

## Related Issues

#259 

