### PR TITLE
Center single page PDF on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Always show stitch menu button regardless of the number of pages in the PDF
 - Disabled rendering of PDF links
+- A single page PDF is centered on load
 
 ### Fixed
 

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -455,6 +455,7 @@ export default function Page() {
                   dispatchStitchSettings={dispatchStitchSettings}
                   setPdfLoadStatus={setPdfLoadStatus}
                   setLineThicknessStatus={setLineThicknessStatus}
+                  gridCenter={getCenterPoint(+width, +height, unitOfMeasure)}
                 />
               </Draggable>
               <OverlayCanvas


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have run `yarn build` to ensure that the project builds successfully.
- [x] I have updated `CHANGELOG.md` with the necessary changes made in this pull request.

## Description

When a single page PDF is uploaded, it is automatically centered in the PDF viewer.

## Related Issues

#278 
