### PR TITLE
Close overlay menu on click outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Always show stitch menu button regardless of the number of pages in the PDF
 
+### Fixed
+
+- Close overlay options menu on click outside
+
 ## [1.0.2] - 2024-05-25
 
 ### Changed

--- a/app/_components/buttons/dropdown-checkbox-icon-button.tsx
+++ b/app/_components/buttons/dropdown-checkbox-icon-button.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef } from "react";
 import { IconButton } from "@/_components/buttons/icon-button";
 import Tooltip from "@/_components/tooltip/tooltip";
 import { visible } from "@/_components/theme/css-functions";
+import useOnClickOutside from "@/_hooks/use-on-click-outside";
 
 type BooleanOption = {
   icon: React.ReactNode;
@@ -48,21 +49,7 @@ export function DropdownCheckboxIconButton<T>({
   const dropdownClasses =
     "absolute left-0 mt-2 min-w-max bg-white dark:bg-gray-800 rounded-md shadow-lg z-10";
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("pointerdown", handleClickOutside);
-    return () => {
-      document.removeEventListener("pointerdown", handleClickOutside);
-    };
-  }, [containerRef]);
+  useOnClickOutside(containerRef, () => setIsOpen(false));
 
   const updateOption = (key: keyof T, value: boolean): void => {
     const updatedOptions = {

--- a/app/_components/buttons/dropdown-checkbox-icon-button.tsx
+++ b/app/_components/buttons/dropdown-checkbox-icon-button.tsx
@@ -58,9 +58,9 @@ export function DropdownCheckboxIconButton<T>({
       }
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("pointerdown", handleClickOutside);
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("pointerdown", handleClickOutside);
     };
   }, [containerRef]);
 

--- a/app/_components/buttons/dropdown-icon-button.tsx
+++ b/app/_components/buttons/dropdown-icon-button.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef } from "react";
 import { IconButton } from "@/_components/buttons/icon-button";
 import Tooltip from "@/_components/tooltip/tooltip";
 import { visible } from "@/_components/theme/css-functions";
 import CheckIcon from "@/_icons/check-icon";
+import useOnClickOutside from "@/_hooks/use-on-click-outside";
 
 export function DropdownIconButton<T>({
   icon,
@@ -39,21 +40,7 @@ export function DropdownIconButton<T>({
   const dropdownClasses =
     "absolute mt-2 bg-white dark:bg-gray-800 rounded-md shadow-lg";
 
-  useEffect(() => {
-    const handleClickOutside = (event: PointerEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("pointerdown", handleClickOutside);
-    return () => {
-      document.removeEventListener("pointerdown", handleClickOutside);
-    };
-  }, [containerRef]);
+  useOnClickOutside(containerRef, () => setIsOpen(false));
 
   return (
     <div

--- a/app/_components/dropdown/dropdown.tsx
+++ b/app/_components/dropdown/dropdown.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef } from "react";
+import useOnClickOutside from "@/_hooks/use-on-click-outside";
+import { useRef } from "react";
 
 export function Dropdown({
   position,
@@ -12,22 +13,11 @@ export function Dropdown({
   onClose: () => void;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
-
-  const handleClickAway = useCallback(
-    (event: any) => {
-      if (open && !ref?.current?.contains(event.target)) {
-        onClose();
-      }
-    },
-    [open, onClose],
-  );
-
-  useEffect(() => {
-    window.addEventListener("click", handleClickAway);
-    return () => {
-      window.removeEventListener("click", handleClickAway);
-    };
-  }, [handleClickAway]);
+  useOnClickOutside(ref, () => {
+    if (open) {
+      onClose();
+    }
+  });
 
   function getPosition() {
     if (!position || position === "left") {

--- a/app/_hooks/use-on-click-outside.ts
+++ b/app/_hooks/use-on-click-outside.ts
@@ -1,0 +1,27 @@
+import { RefObject, useEffect, useRef } from "react";
+
+export default function useOnClickOutside(
+  containerRef: RefObject<HTMLElement>,
+  callback: () => void,
+) {
+  // Store callback in a ref so that we get a stable reference for the click handler
+  const callbackRef = useRef<() => void>(callback);
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+  useEffect(() => {
+    const handleClickOutside = (event: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        callbackRef.current();
+      }
+    };
+
+    document.addEventListener("pointerdown", handleClickOutside);
+    return () => {
+      document.removeEventListener("pointerdown", handleClickOutside);
+    };
+  }, [containerRef]);
+}


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have run `yarn build` to ensure that the project builds successfully.
- [x] I have updated `CHANGELOG.md` with the necessary changes made in this pull request.

## Description

I don't fully understand the cause, but clicks outside the overlay options menu would only trigger the `mousedown` event when the click was inside the header - not when it was on the main part of the page where the PDF gets rendered. The `pointerdown` event, however, _does_ get triggered everywhere so this PR switches to using that event everywhere.
Since there are three dropdown components that all run the same logic, I've extracted a hook for this.

<!-- Provide a brief description of the changes made in this pull request -->

## Related Issues

Fixes https://github.com/Pattern-Projector/pattern-projector/issues/262

<!-- List any related issues or pull requests -->

## TODO

<!-- List tasks to complete before merging -->
