### PR TITLE
Stitch overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't allow zero for width and height
+- Export with the largest page size to avoid incorrect overlap when different sized pages in range
 
 ## [1.1.1] - 2024-10-03
 

--- a/app/_lib/pdfstitcher.ts
+++ b/app/_lib/pdfstitcher.ts
@@ -28,16 +28,18 @@ function trimmedPageSize(
 ) {
   /**
    * Computes the size for each trimmed page.
-   * Assumes that all selected pages are the same!
+   * Chooses the largest page width and height from the user specified page range to match how the pdf viewer works.
    */
-  const firstRealPage = (pages.find((p) => p > 0) || 1) - 1;
-  const firstPage = inDoc.getPage(firstRealPage);
+  let width = 0;
+  let height = 0;
+  for (const page of pages) {
+    const p = inDoc.getPage(page - 1);
+    const pageSize = p.getTrimBox() || p.getMediaBox();
+    width = Math.max(width, pageSize.width - settings.edgeInsets.horizontal);
+    height = Math.max(height, pageSize.height - settings.edgeInsets.vertical);
+  }
 
-  const pageSize = firstPage.getTrimBox() || firstPage.getMediaBox();
-  const width = pageSize.width - settings.edgeInsets.horizontal;
-  const height = pageSize.height - settings.edgeInsets.vertical;
-
-  return { width: width, height: height };
+  return { width, height };
 }
 
 function initDoc(doc: PDFDocument, pages: number[]): Map<number, PDFRef> {


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have run `yarn build` to ensure that the project builds successfully.
- [x] I have updated `CHANGELOG.md` with the necessary changes made in this pull request.
- [x] I have added documentation for any new functionality from this pull request.

## Description

Change page size in PDFStitcher lib to be the max page width and height in the user specified page range to match how the [PDF viewer works](https://github.com/Pattern-Projector/pattern-projector/blob/9a72f843eb7375e2f00962b443b9bd764b641a87/app/_components/pdf-viewer.tsx#L222)

## Related Issues

#356
After sleeping on it, I think rather than a popup, this fix makes sense. It's not ideal, but at least it matches how the viewer behaves!

