### PR TITLE
Add vertical alignment option for stitching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Português (Brasil), Suomi, and 简体中文 translations
 - Opened file name shows in the stitch menu
 - Screenshot testing
+- Add vertical alignment option for stitching
 
 ### Fixed
 

--- a/app/[locale]/calibrate/page.tsx
+++ b/app/[locale]/calibrate/page.tsx
@@ -51,6 +51,7 @@ import OverlayCanvas from "@/_components/canvases/overlay-canvas";
 import stitchSettingsReducer from "@/_reducers/stitchSettingsReducer";
 import {
   LineDirection,
+  VerticalAlignment,
   StitchSettings,
 } from "@/_lib/interfaces/stitch-settings";
 import { IconButton } from "@/_components/buttons/icon-button";
@@ -81,6 +82,7 @@ const defaultStitchSettings = {
   edgeInsets: { horizontal: 0, vertical: 0 },
   pageRange: "1-",
   lineDirection: LineDirection.Column,
+  verticalAlignment: VerticalAlignment.Top,
 } as StitchSettings;
 
 export default function Page() {
@@ -314,6 +316,10 @@ export default function Page() {
         if (!stitchSettings.lineDirection) {
           // For people who saved stitch settings before Line Direction was an option
           stitchSettings.lineDirection = LineDirection.Column;
+        }
+        if (!stitchSettings.verticalAlignment) {
+          // For people who saved stitch settings before Vertical Alignment was an option
+          stitchSettings.verticalAlignment = VerticalAlignment.Top;
         }
         dispatchStitchSettings({ type: "set", stitchSettings });
       } else {

--- a/app/_components/menus/stitch-menu.tsx
+++ b/app/_components/menus/stitch-menu.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from "next-intl";
 import StepperInput from "@/_components/stepper-input";
 import {
   LineDirection,
+  VerticalAlignment,
   StitchSettings,
 } from "@/_lib/interfaces/stitch-settings";
 import { StitchSettingsAction } from "@/_reducers/stitchSettingsReducer";
@@ -120,6 +121,27 @@ export default function StitchMenu({
             }
           />
         </div>
+        <InlineSelect
+          handleChange={(e) => {
+            dispatchStitchSettings({
+              type: "set",
+              stitchSettings: {
+                ...stitchSettings,
+                verticalAlignment:
+                  VerticalAlignment[
+                    e.target.value as keyof typeof VerticalAlignment
+                  ],
+              },
+            });
+          }}
+          id="vertical-alignment"
+          name="vertical-alignment"
+          value={stitchSettings.verticalAlignment}
+          options={[
+            { value: VerticalAlignment.Top, label: t("topAlignment") },
+            { value: VerticalAlignment.Bottom, label: t("bottomAlignment") },
+          ]}
+        ></InlineSelect>
         <StepperInput
           inputClassName="w-12"
           handleChange={handleEdgeInsetChange}

--- a/app/_components/pdf-viewer.tsx
+++ b/app/_components/pdf-viewer.tsx
@@ -18,6 +18,7 @@ import { RenderContext } from "@/_hooks/use-render-context";
 import { useTransformerContext } from "@/_hooks/use-transform-context";
 import {
   LineDirection,
+  VerticalAlignment,
   StitchSettings,
 } from "@/_lib/interfaces/stitch-settings";
 import { StitchSettingsAction } from "@/_reducers/stitchSettingsReducer";
@@ -186,6 +187,10 @@ export default function PdfViewer({
           marginRight: cssEdgeInsets.horizontal,
           marginBottom: cssEdgeInsets.vertical,
           filter: filter,
+          transform:
+            stitchSettings.verticalAlignment == VerticalAlignment.Top
+              ? `scaleY(1)`
+              : `scaleY(-1)`,
         }}
       >
         {pages.map((value, index) => {
@@ -199,6 +204,10 @@ export default function PdfViewer({
                   cssEdgeInsets.horizontal == 0 && cssEdgeInsets.vertical == 0
                     ? "normal"
                     : "darken",
+                transform:
+                  stitchSettings.verticalAlignment == VerticalAlignment.Top
+                    ? `scaleY(1)`
+                    : `scaleY(-1)`,
               }}
             >
               {value != 0 && (

--- a/app/_lib/interfaces/stitch-settings.ts
+++ b/app/_lib/interfaces/stitch-settings.ts
@@ -5,10 +5,16 @@ export enum LineDirection {
   Column = "Column",
 }
 
+export enum VerticalAlignment {
+  Top = "Top",
+  Bottom = "Bottom",
+}
+
 export interface StitchSettings {
   key: string;
   lineCount: number;
   edgeInsets: EdgeInsets;
   pageRange: string;
   lineDirection: LineDirection;
+  verticalAlignment: VerticalAlignment;
 }

--- a/app/_lib/pdfstitcher.ts
+++ b/app/_lib/pdfstitcher.ts
@@ -19,6 +19,7 @@ import {
 } from "@cantoo/pdf-lib";
 import {
   LineDirection,
+  VerticalAlignment,
   StitchSettings,
 } from "@/_lib/interfaces/stitch-settings";
 import { getPageNumbers, getRowsColumns } from "./get-page-numbers";
@@ -221,6 +222,11 @@ async function tilePages(doc: PDFDocument, settings: StitchSettings) {
   // Loop through the pages and copy them to the output document
   let x = 0;
   let y = outHeight - pageSize.height;
+  let yDirection = 1;
+  if (settings.verticalAlignment == VerticalAlignment.Bottom) {
+    y = 0;
+    yDirection = -1;
+  }
 
   // define the commands to draw the page and the resources dictionary
   const commands: PDFOperator[] = [];
@@ -253,14 +259,22 @@ async function tilePages(doc: PDFDocument, settings: StitchSettings) {
         x += pageSize.width;
         if (x > outWidth - margin) {
           x = 0;
-          y -= pageSize.height;
+          y -= pageSize.height * yDirection;
         }
         break;
       case LineDirection.Row:
-        y -= pageSize.height;
-        if (y < -margin) {
-          y = outHeight - pageSize.height;
-          x += pageSize.width;
+        if (settings.verticalAlignment == VerticalAlignment.Bottom) {
+          y -= pageSize.height * yDirection;
+          if (y > outHeight - margin) {
+            y = 0;
+            x += pageSize.width;
+          }
+        } else {
+          y -= pageSize.height;
+          if (y < -margin) {
+            y = outHeight - pageSize.height;
+            x += pageSize.width;
+          }
         }
         break;
     }

--- a/messages/en.json
+++ b/messages/en.json
@@ -297,6 +297,8 @@
   "StitchMenu": {
     "columnCount": "Columns",
     "rowCount": "Rows",
+    "topAlignment": "Top Aliged",
+    "bottomAlignment": "Bottom Aligned",
     "pageRange": "Stitch Pages",
     "horizontal": "Horizontal Overlap",
     "vertical": "Vertical Overlap",


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have run `yarn build` to ensure that the project builds successfully.
- [x] I have updated `CHANGELOG.md` with the necessary changes made in this pull request.
- [ ] I have added documentation for any new functionality from this pull request.

## Description

Adds an vertical alignment option for the stitching function. Some patterns are sliced in a way, that the bottom left corner is the first page. With this pull request it is now possible, to set the starting point to that corner (vertical alignment: bottom). With the default vertical alignment top, the stitching function works the same way as before.

<img width="365" height="524" alt="vaglin" src="https://github.com/user-attachments/assets/38e2b121-5886-4d60-8d9b-dd2a93a0440c" />

