### PR TITLE
Fix for #429 zoom out switch to calibrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Calibration breaking when zoomed out and switch to calibrate to recalibrate.
+
 ## [1.3.0] - 2025-06-25
 
 ### Added

--- a/app/_components/draggable.tsx
+++ b/app/_components/draggable.tsx
@@ -226,6 +226,26 @@ export default function Draggable({
     setPerspective,
   ]);
 
+  useEffect(() => {
+    if (isCalibrating && restoreTransforms !== null) {
+      transformer.setLocalTransform(restoreTransforms.localTransform);
+      setCalibrationTransform(restoreTransforms.calibrationTransform);
+      setPerspective(inverse(restoreTransforms.calibrationTransform));
+      setRestoreTransforms(null);
+      setZoomedOut(false);
+      setMagnifying(false);
+    }
+  }, [
+    isCalibrating,
+    restoreTransforms,
+    transformer,
+    setCalibrationTransform,
+    setPerspective,
+    setRestoreTransforms,
+    setZoomedOut,
+    setMagnifying,
+  ]);
+
   let cursorMode = "cursor-grab";
 
   if (zoomedOut || magnifying) {


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have run `yarn build` to ensure that the project builds successfully.
- [x] I have updated `CHANGELOG.md` with the necessary changes made in this pull request.
- [x] I have added documentation for any new functionality from this pull request.

## Description

The app was not restoring transforms when switching from projecting to calibrating

## Related Issues

#429 

## TODO

